### PR TITLE
Add a proper issue template for Suggest a Resource

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-resource.yml
+++ b/.github/ISSUE_TEMPLATE/add-resource.yml
@@ -1,0 +1,56 @@
+name: Add Resource
+description: Suggest a resource for the CRIYPT Resources page
+labels: ["add-resource"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing! Fill in the details below and a PR will be created automatically for review.
+
+  - type: input
+    id: title
+    attributes:
+      label: Resource Title
+      placeholder: e.g. A Graduate Course in Applied Cryptography — Boneh & Shoup
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Resource URL
+      placeholder: https://
+    validations:
+      required: true
+
+  - type: dropdown
+    id: section
+    attributes:
+      label: Where should this go?
+      description: Pick the card/section this resource best fits under
+      options:
+        - "Resources page — Textbooks"
+        - "Resources page — Online Courses"
+        - "Resources page — Research Groups"
+        - "Resources page — Conference Deadlines"
+        - "Resources page — Software & Libraries"
+        - "Resources page — Standards"
+        - "Resources page — Reading Lists"
+        - "Resources page — Blogs & Newsletters"
+        - "Secure Computation topic page — Courses"
+        - "Secure Computation topic page — Winter Schools & Lecture Series"
+        - "Secure Computation topic page — Foundational Papers"
+        - "Secure Computation topic page — Textbooks"
+        - "Secure Computation topic page — Frameworks & Libraries"
+        - "Secure Computation topic page — Useful Resources"
+        - "Fully Homomorphic Encryption topic page (still under construction)"
+        - "Zero-Knowledge Proofs topic page (still under construction)"
+        - "Not sure / other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Why is this useful? (optional)
+      description: A short note helps reviewers — e.g. what makes it worth including

--- a/.github/workflows/process-submissions.yml
+++ b/.github/workflows/process-submissions.yml
@@ -359,3 +359,120 @@ jobs:
               issue_number: issue.number,
               body: `✅ Your collaboration post has been submitted for review: ${pr.data.html_url}\n\nOnce merged, it will appear on the [Collaborations page](https://cryptography-research-india.github.io/collaborations/). Thank you for sharing your work with the community! 🤝`,
             });
+
+  # ── Add Resource ─────────────────────────────────────────────────────────────
+  add-resource:
+    if: contains(github.event.issue.labels.*.name, 'add-resource')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Parse issue and create resource PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body  = issue.body || '';
+
+            function field(label) {
+              const re = new RegExp(`### ${label}\\s*\\n+([\\s\\S]*?)(?=\\n### |$)`, 'i');
+              const m  = body.match(re);
+              return m ? m[1].trim() : '';
+            }
+
+            const title   = field('Resource Title');
+            const url     = field('Resource URL');
+            const section = field('Where should this go\\?');
+            const why     = field('Why is this useful\\? \\(optional\\)');
+
+            if (!title || !url || !section) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: '❌ Could not parse required fields. Please ensure Title, URL, and Section are filled in.',
+              });
+              return;
+            }
+
+            // Map dropdown choice -> file + anchor comment. Sections not listed
+            // here (placeholder topic pages, "Not sure / other") have no
+            // structured list yet, so they fall through to a manual-review comment.
+            const SECTION_MAP = {
+              'Resources page — Textbooks':                                     { file: '_pages/resources.md', anchor: 'Textbooks' },
+              'Resources page — Online Courses':                                { file: '_pages/resources.md', anchor: 'Online Courses' },
+              'Resources page — Research Groups':                               { file: '_pages/resources.md', anchor: 'Research Groups' },
+              'Resources page — Conference Deadlines':                          { file: '_pages/resources.md', anchor: 'Conference Deadlines' },
+              'Resources page — Software & Libraries':                          { file: '_pages/resources.md', anchor: 'Software Libraries' },
+              'Resources page — Standards':                                     { file: '_pages/resources.md', anchor: 'Standards' },
+              'Resources page — Reading Lists':                                 { file: '_pages/resources.md', anchor: 'Reading Lists' },
+              'Resources page — Blogs & Newsletters':                           { file: '_pages/resources.md', anchor: 'Blogs & News' },
+              'Secure Computation topic page — Courses':                        { file: '_resources/topics/secure-computation.md', anchor: 'Courses' },
+              'Secure Computation topic page — Winter Schools & Lecture Series': { file: '_resources/topics/secure-computation.md', anchor: 'Winter Schools & Lecture Series' },
+              'Secure Computation topic page — Foundational Papers':            { file: '_resources/topics/secure-computation.md', anchor: 'Foundational Papers' },
+              'Secure Computation topic page — Textbooks':                      { file: '_resources/topics/secure-computation.md', anchor: 'Textbooks' },
+              'Secure Computation topic page — Frameworks & Libraries':         { file: '_resources/topics/secure-computation.md', anchor: 'Frameworks & Libraries' },
+              'Secure Computation topic page — Useful Resources':               { file: '_resources/topics/secure-computation.md', anchor: 'Useful Resources' },
+            };
+
+            const target = SECTION_MAP[section];
+
+            if (!target) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: `✅ Thanks for the suggestion! **${title}** (${url}) has been noted for **${section}**. That page doesn't have a curated list yet, so a maintainer will add it by hand once the page is built out.`,
+              });
+              return;
+            }
+
+            const { data: fileData } = await github.rest.repos.getContent({
+              ...context.repo,
+              path: target.file,
+              ref: 'master',
+            });
+            const existing = Buffer.from(fileData.content, 'base64').toString('utf8');
+
+            const anchor = `<!-- ${target.anchor} -->`;
+            const anchorIdx = existing.indexOf(anchor);
+            const closeTagIdx = anchorIdx === -1 ? -1 : existing.indexOf('</ul>', anchorIdx);
+
+            if (closeTagIdx === -1) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: `❌ Could not locate the "${section}" section automatically. A maintainer will add this by hand: **${title}** (${url}).`,
+              });
+              return;
+            }
+
+            // Insert at the start of the `</ul>` line so its own indentation
+            // stays put and the new <li> gets a clean line of its own.
+            const lineStart = existing.lastIndexOf('\n', closeTagIdx) + 1;
+            const newLi = `          <li><a href="${url}" target="_blank" rel="noopener">${title}</a></li>\n`;
+            const newContent = existing.slice(0, lineStart) + newLi + existing.slice(lineStart);
+
+            const branch = `submission/resource-${issue.number}`;
+            const { data: ref } = await github.rest.git.getRef({ ...context.repo, ref: 'heads/master' });
+            await github.rest.git.createRef({ ...context.repo, ref: `refs/heads/${branch}`, sha: ref.object.sha });
+            await github.rest.repos.createOrUpdateFileContents({
+              ...context.repo,
+              path: target.file,
+              message: `Add resource: ${title}`,
+              content: Buffer.from(newContent).toString('base64'),
+              sha: fileData.sha,
+              branch,
+            });
+
+            const pr = await github.rest.pulls.create({
+              ...context.repo,
+              title: `Add resource: ${title}`,
+              body: `Submitted via [Issue #${issue.number}](${issue.html_url}) by @${issue.user.login}.\n\n**Section:** ${section}\n**URL:** ${url}\n${why ? `**Why:** ${why}\n` : ''}\n### Checklist\n- [ ] Link works and matches the title\n- [ ] Belongs in this section\n- [ ] No duplicate already listed`,
+              head: branch,
+              base: 'master',
+            });
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: issue.number,
+              body: `✅ Thanks! A PR has been created for review: ${pr.data.html_url}`,
+            });

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -80,7 +80,7 @@ permalink: /resources/
         </ul>
       </div>
 
-      <!-- Conferences -->
+      <!-- Conference Deadlines -->
       <div class="resource-card capped glass" tabindex="0" role="button" aria-haspopup="dialog">
         <div class="resource-card-icon" style="background:rgba(245,158,11,0.12);">
           ⏰
@@ -111,7 +111,7 @@ permalink: /resources/
         </ul>
       </div>
 
-      <!-- Competitions & Challenges -->
+      <!-- Standards -->
       <div class="resource-card capped glass" tabindex="0" role="button" aria-haspopup="dialog">
         <div class="resource-card-icon" style="background:rgba(124,58,237,0.15);">
           🏆
@@ -162,7 +162,7 @@ permalink: /resources/
 
     <div class="glass" style="margin-top:2.5rem;border-radius:var(--radius-lg);padding:2rem;text-align:center;">
       <p style="margin-bottom:1rem;font-size:0.95rem;">Know a resource that should be listed here? Let us know!</p>
-      <a href="https://github.com/cryptography-research-india/cryptography-research-india.github.io/issues/new?title=[RESOURCE]+Resource+Name"
+      <a href="https://github.com/cryptography-research-india/cryptography-research-india.github.io/issues/new?template=add-resource.yml"
          target="_blank" rel="noopener" class="btn btn-primary">
         Suggest a Resource
       </a>

--- a/_resources/topics/fully-homomorphic-encryption.md
+++ b/_resources/topics/fully-homomorphic-encryption.md
@@ -22,7 +22,7 @@ permalink: /resources/topics/fully-homomorphic-encryption/
     <div class="glass" style="border-radius:var(--radius-lg);padding:2.5rem;text-align:center;">
       <p style="margin-bottom:1rem;font-size:0.95rem;">This page is under construction. A curated set of courses, papers, textbooks, and libraries on Fully Homomorphic Encryption will be added here soon.</p>
       <p style="margin-bottom:1rem;font-size:0.95rem;">Have a resource to suggest in the meantime? Let us know!</p>
-      <a href="https://github.com/cryptography-research-india/cryptography-research-india.github.io/issues/new?title=[RESOURCE]+Resource+Name"
+      <a href="https://github.com/cryptography-research-india/cryptography-research-india.github.io/issues/new?template=add-resource.yml"
          target="_blank" rel="noopener" class="btn btn-primary">
         Suggest a Resource
       </a>

--- a/_resources/topics/zero-knowledge-proofs.md
+++ b/_resources/topics/zero-knowledge-proofs.md
@@ -22,7 +22,7 @@ permalink: /resources/topics/zero-knowledge-proofs/
     <div class="glass" style="border-radius:var(--radius-lg);padding:2.5rem;text-align:center;">
       <p style="margin-bottom:1rem;font-size:0.95rem;">This page is under construction. A curated set of courses, papers, textbooks, and libraries on Zero-Knowledge Proofs will be added here soon.</p>
       <p style="margin-bottom:1rem;font-size:0.95rem;">Have a resource to suggest in the meantime? Let us know!</p>
-      <a href="https://github.com/cryptography-research-india/cryptography-research-india.github.io/issues/new?title=[RESOURCE]+Resource+Name"
+      <a href="https://github.com/cryptography-research-india/cryptography-research-india.github.io/issues/new?template=add-resource.yml"
          target="_blank" rel="noopener" class="btn btn-primary">
         Suggest a Resource
       </a>


### PR DESCRIPTION
The button previously opened a blank GitHub issue with only a pre-filled title — no fields, and no way to say which of the now several resource cards/pages a suggestion belongs to.

- .github/ISSUE_TEMPLATE/add-resource.yml adds a form with Title, URL, a dropdown covering every section on the Resources page and the Secure Computation topic page (plus the still-under-construction FHE/ZKP pages and a catch-all), and an optional note.
- process-submissions.yml gains an add-resource job that inserts the new link into the right <ul> (matched by file + section anchor comment) and opens a PR, mirroring the existing researcher/position/ collaboration/blog-post automations. Sections without a curated list yet just get a comment for manual follow-up.
- Renamed two stale anchor comments in resources.md (Conferences -> Conference Deadlines, Competitions & Challenges -> Standards) so they match the current card titles and the automation's mapping.
- All three "Suggest a Resource" buttons now link to ?template=add-resource.yml instead of a bare issue.