### PR TITLE
Fix researcher/position submission bugs, wire up Positions and Catego…

### DIFF
--- a/.github/scripts/validate_submissions.rb
+++ b/.github/scripts/validate_submissions.rb
@@ -1,0 +1,174 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Validates the data files that the community-submission automation
+# (.github/workflows/process-submissions.yml) writes to, so a malformed or
+# incomplete auto-generated PR fails CI instead of silently merging broken
+# data (e.g. a missing required field, a bad URL, or a duplicate entry).
+#
+# Checks, per source:
+#   _data/names-people.yml   - required keys, tag vocabulary, URL shape, dup names
+#   _data/collaborations.yml - required keys, email shape, URL shape, dup (name+topic)
+#   _positions/*.md          - required front matter keys, URL shape, dup (title+org)
+#
+# Exits non-zero (and prints "::error::" annotations) if any check fails.
+
+require "yaml"
+require "date"
+
+ROOT = File.expand_path("../..", __dir__)
+errors = []
+
+URL_RE = %r{\Ahttps?://[^\s]+\z}
+EMAIL_RE = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+VALID_SECTOR_TAGS = %w[ACADEMIA INDUSTRY].freeze
+VALID_LOCATION_TAGS = %w[WORKING_IN_INDIA WORKING_ABROAD].freeze
+
+def error(errors, source, message)
+  errors << "#{source}: #{message}"
+  puts "::error::#{source}: #{message}"
+end
+
+def normalize(str)
+  str.to_s.strip.downcase.gsub(/\s+/, " ")
+end
+
+# ── _data/names-people.yml ────────────────────────────────────────────────
+people_path = File.join(ROOT, "_data/names-people.yml")
+if File.exist?(people_path)
+  people = YAML.safe_load_file(people_path, permitted_classes: [Date], aliases: true) || []
+  seen_names = {}
+
+  people.each_with_index do |person, i|
+    src = "_data/names-people.yml entry ##{i + 1} (#{person['name'] || 'unnamed'})"
+
+    %w[name designation affiliation].each do |key|
+      error(errors, src, "missing required field `#{key}`") if person[key].to_s.strip.empty?
+    end
+
+    if person["research"].to_s.strip.empty?
+      error(errors, src, "missing required field `research`")
+    end
+
+    tags = person["tags"] || []
+    unless tags.is_a?(Array) && (tags & VALID_SECTOR_TAGS).any?
+      error(errors, src, "`tags` must include one of #{VALID_SECTOR_TAGS.join(' / ')}")
+    end
+    unless tags.is_a?(Array) && (tags & VALID_LOCATION_TAGS).any?
+      error(errors, src, "`tags` must include one of #{VALID_LOCATION_TAGS.join(' / ')}")
+    end
+
+    %w[webpage webpagelab].each do |key|
+      value = person[key]
+      if value && !value.to_s.strip.empty? && value.to_s.strip !~ URL_RE
+        error(errors, src, "`#{key}` is not a valid http(s) URL: #{value}")
+      end
+    end
+
+    next if person["name"].to_s.strip.empty?
+
+    key = normalize(person["name"])
+    if seen_names[key]
+      error(errors, src, "duplicate researcher name (also entry ##{seen_names[key]})")
+    else
+      seen_names[key] = i + 1
+    end
+  end
+else
+  puts "SKIP  #{people_path} not found"
+end
+
+# ── _data/collaborations.yml ──────────────────────────────────────────────
+collab_path = File.join(ROOT, "_data/collaborations.yml")
+if File.exist?(collab_path)
+  collaborations = YAML.safe_load_file(collab_path, permitted_classes: [Date], aliases: true) || []
+  seen_collabs = {}
+
+  collaborations.each_with_index do |collab, i|
+    src = "_data/collaborations.yml entry ##{i + 1} (#{collab['name'] || 'unnamed'})"
+
+    %w[name topic seeking description contact].each do |key|
+      error(errors, src, "missing required field `#{key}`") if collab[key].to_s.strip.empty?
+    end
+
+    contact = collab["contact"]
+    if contact && !contact.to_s.strip.empty? && contact.to_s.strip !~ EMAIL_RE
+      error(errors, src, "`contact` is not a valid email address: #{contact}")
+    end
+
+    webpage = collab["webpage"]
+    if webpage && !webpage.to_s.strip.empty? && webpage.to_s.strip !~ URL_RE
+      error(errors, src, "`webpage` is not a valid http(s) URL: #{webpage}")
+    end
+
+    next if collab["name"].to_s.strip.empty? || collab["topic"].to_s.strip.empty?
+
+    key = "#{normalize(collab['name'])}::#{normalize(collab['topic'])}"
+    if seen_collabs[key]
+      error(errors, src, "duplicate collaboration post (same name + topic as entry ##{seen_collabs[key]})")
+    else
+      seen_collabs[key] = i + 1
+    end
+  end
+else
+  puts "SKIP  #{collab_path} not found"
+end
+
+# ── _positions/*.md ────────────────────────────────────────────────────────
+positions_dir = File.join(ROOT, "_positions")
+if Dir.exist?(positions_dir)
+  seen_positions = {}
+
+  Dir.glob(File.join(positions_dir, "*.md")).sort.each do |path|
+    rel = path.sub("#{ROOT}/", "")
+    raw = File.read(path)
+
+    unless raw.start_with?("---")
+      error(errors, rel, "missing YAML front matter")
+      next
+    end
+
+    parts = raw.split(/^---\s*$/, 3)
+    if parts.length < 3
+      error(errors, rel, "malformed front matter (no closing `---`)")
+      next
+    end
+
+    front = YAML.safe_load(parts[1], permitted_classes: [Date], aliases: true) || {}
+
+    %w[title organization link].each do |key|
+      error(errors, rel, "missing required field `#{key}`") if front[key].to_s.strip.empty?
+    end
+
+    link = front["link"]
+    if link && !link.to_s.strip.empty? && link.to_s.strip !~ URL_RE
+      error(errors, rel, "`link` is not a valid http(s) URL: #{link}")
+    end
+
+    deadline = front["deadline"]
+    if deadline && !(deadline.is_a?(Date) || deadline.to_s.strip =~ /\A\d{4}-\d{2}-\d{2}\z/)
+      error(errors, rel, "`deadline` must be an ISO date (YYYY-MM-DD): #{deadline}")
+    end
+
+    next if front["title"].to_s.strip.empty? || front["organization"].to_s.strip.empty?
+
+    key = "#{normalize(front['title'])}::#{normalize(front['organization'])}"
+    if seen_positions[key]
+      error(errors, rel, "duplicate position (same title + organization as #{seen_positions[key]})")
+    else
+      seen_positions[key] = rel
+    end
+  end
+else
+  puts "SKIP  #{positions_dir}/ not found"
+end
+
+# ── Summary ────────────────────────────────────────────────────────────────
+if errors.empty?
+  puts "✅ All submission data passed validation."
+  exit 0
+else
+  puts "\n❌ #{errors.size} validation error(s) found:"
+  errors.each { |e| puts "  - #{e}" }
+  exit 1
+end

--- a/.github/workflows/process-submissions.yml
+++ b/.github/workflows/process-submissions.yml
@@ -60,13 +60,14 @@ jobs:
               .map(l => l.replace(/^[-*]\s*/, '').trim())
               .filter(Boolean);
 
-            // Build YAML entry
+            // Build YAML entry. Note: the site schema (person-card.html, main.js,
+            // home.html) expects `research` as a single comma-joined string and
+            // `webpagelab` (not `lab`) for the lab/group URL — must match exactly.
             let yaml = `- name: ${name}\n  designation: ${designation}\n  affiliation: ${affiliation}\n`;
             if (webpage && webpage !== '_No response_') yaml += `  webpage: ${webpage}\n`;
-            if (lab && lab !== '_No response_')         yaml += `  lab: ${lab}\n`;
+            if (lab && lab !== '_No response_')         yaml += `  webpagelab: ${lab}\n`;
             if (researchAreas.length) {
-              yaml += `  research_areas:\n`;
-              researchAreas.forEach(a => { yaml += `    - ${a}\n`; });
+              yaml += `  research: ${researchAreas.join(', ')}\n`;
             }
             yaml += `  tags: [${tags.join(', ')}]\n`;
 
@@ -149,7 +150,21 @@ jobs:
             const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
             const filename = `_positions/${date}-${slug}.md`;
 
-            const content = `---\ntitle: "${title}"\norganization: "${org}"\ntype: "${type}"\nlocation: "${location}"\ndeadline: "${deadline}"\nlink: "${link}"\n${contact && contact !== '_No response_' ? `contact: "${contact}"\n` : ''}date: ${date}\n---\n\n${description}\n`;
+            // The positions page sorts/expires listings by `deadline`, which needs
+            // to be a real ISO date to compare. Free-text deadlines (e.g. "Rolling",
+            // "Open until filled") are kept as `deadline_display` and treated as
+            // always-open instead of being silently misparsed.
+            const rawDeadline = deadline && deadline !== '_No response_' ? deadline.trim() : '';
+            const isIsoDeadline = /^\d{4}-\d{2}-\d{2}$/.test(rawDeadline);
+
+            let frontmatter = `---\ntitle: "${title}"\norganization: "${org}"\ntype: "${type}"\nlocation: "${location}"\n`;
+            if (isIsoDeadline) {
+              frontmatter += `deadline: ${rawDeadline}\n`;
+            } else if (rawDeadline) {
+              frontmatter += `deadline_display: "${rawDeadline.replace(/"/g, '\\"')}"\n`;
+            }
+            frontmatter += `link: "${link}"\n${contact && contact !== '_No response_' ? `contact: "${contact}"\n` : ''}date: ${date}\n---\n\n${description}\n`;
+            const content = frontmatter;
 
             // Create branch and commit
             const branch = `submission/position-${issue.number}`;

--- a/.github/workflows/validate-submissions.yml
+++ b/.github/workflows/validate-submissions.yml
@@ -1,0 +1,17 @@
+name: Validate Submissions
+
+on:
+  pull_request:
+    paths:
+      - "_data/names-people.yml"
+      - "_data/collaborations.yml"
+      - "_positions/**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate submission data
+        run: ruby .github/scripts/validate_submissions.rb

--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,8 @@ plugins:
 collections:
   resources:
     output: true
+  positions:
+    output: false
 
 # Defaults
 defaults:

--- a/_includes/position-card.html
+++ b/_includes/position-card.html
@@ -1,0 +1,40 @@
+{% assign pos = include.position %}
+{% assign closed = include.closed %}
+<article class="position-card glass{% if closed %} position-card-closed{% endif %}">
+  <div class="position-card-header">
+    <div class="position-card-heading">
+      <h3 class="position-card-title">{{ pos.title }}</h3>
+      <p class="position-card-org">{{ pos.organization }}{% if pos.location %} &middot; {{ pos.location }}{% endif %}</p>
+    </div>
+    {% if closed %}
+      <span class="badge position-badge-closed">Closed</span>
+    {% elsif pos.deadline %}
+      <span class="badge badge-green">Open</span>
+    {% else %}
+      <span class="badge badge-cyan">Rolling</span>
+    {% endif %}
+  </div>
+
+  <div class="position-card-tags">
+    {% if pos.type %}<span class="tag">{{ pos.type }}</span>{% endif %}
+    {% if pos.deadline %}
+      <span class="tag tag-amber">Deadline: {{ pos.deadline | date: "%b %d, %Y" }}</span>
+    {% elsif pos.deadline_display %}
+      <span class="tag tag-amber">Deadline: {{ pos.deadline_display }}</span>
+    {% endif %}
+  </div>
+
+  {% if pos.content and pos.content != "" %}
+  <div class="position-card-desc prose">{{ pos.content }}</div>
+  {% endif %}
+
+  <div class="position-card-footer">
+    <a href="{{ pos.link }}" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+      Details
+    </a>
+    {% if pos.contact %}
+    <a href="mailto:{{ pos.contact }}" class="btn btn-ghost btn-sm">Contact</a>
+    {% endif %}
+  </div>
+</article>

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -7,7 +7,7 @@
       </time>
       {% if post.categories and post.categories.size > 0 %}
         {% for cat in post.categories limit:2 %}
-          <span class="tag tag-category">{{ cat }}</span>
+          <a href="{{ '/categories/' | relative_url }}#{{ cat | slugify }}" class="tag tag-category">{{ cat }}</a>
         {% endfor %}
       {% endif %}
     </div>
@@ -21,7 +21,7 @@
       {% if post.tags and post.tags.size > 0 %}
         <div class="post-tags">
           {% for tag in post.tags limit:3 %}
-            <span class="tag tag-sm">{{ tag }}</span>
+            <a href="{{ '/tags/' | relative_url }}#{{ tag | slugify }}" class="tag tag-sm">{{ tag }}</a>
           {% endfor %}
         </div>
       {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,7 +16,7 @@ layout: default
         </time>
         {% if page.categories %}
           {% for cat in page.categories limit:2 %}
-            <span class="tag tag-category">{{ cat }}</span>
+            <a href="{{ '/categories/' | relative_url }}#{{ cat | slugify }}" class="tag tag-category">{{ cat }}</a>
           {% endfor %}
         {% endif %}
       </div>
@@ -29,7 +29,7 @@ layout: default
       {% if page.tags and page.tags.size > 0 %}
       <div class="post-tags-hero">
         {% for tag in page.tags %}
-          <span class="tag tag-sm">{{ tag }}</span>
+          <a href="{{ '/tags/' | relative_url }}#{{ tag | slugify }}" class="tag tag-sm">{{ tag }}</a>
         {% endfor %}
       </div>
       {% endif %}

--- a/_pages/category-archive.md
+++ b/_pages/category-archive.md
@@ -1,7 +1,48 @@
 ---
-layout: page
+layout: default
 title: "Posts by Category"
 permalink: /categories/
 ---
 
-Browse posts by category on the [Posts](/posts/) page.
+<div class="page-hero">
+  <div class="page-hero-overlay"></div>
+  <div class="container">
+    <h1 class="page-hero-title">Posts by Category</h1>
+    <p class="page-hero-subtitle">Browse CRIYPT community posts grouped by category.</p>
+  </div>
+</div>
+
+<section class="page-content-section">
+  <div class="container">
+
+    {% if site.categories.size > 0 %}
+    <div class="topic-pills">
+      <span class="filter-label">Jump to:</span>
+      {% for category in site.categories %}
+        <a href="#{{ category[0] | slugify }}" class="filter-btn topic-pill">{{ category[0] }} <span class="tag tag-sm">{{ category[1].size }}</span></a>
+      {% endfor %}
+    </div>
+
+    {% for category in site.categories %}
+      {% assign posts_sorted = category[1] | sort: "date" | reverse %}
+      <div class="archive-group" id="{{ category[0] | slugify }}">
+        <div class="section-header archive-group-header">
+          <h2 class="section-title archive-group-title">{{ category[0] }}</h2>
+        </div>
+        <div class="posts-grid posts-grid-full">
+          {% for post in posts_sorted %}
+            {% include post-card.html post=post %}
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+    {% else %}
+    <div class="empty-state glass">
+      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+      <h3>No categories yet</h3>
+      <p>Check back once the community starts publishing posts.</p>
+    </div>
+    {% endif %}
+
+  </div>
+</section>

--- a/_pages/positions.md
+++ b/_pages/positions.md
@@ -32,6 +32,35 @@ permalink: /positions/
       </div>
     </div>
 
+    {% assign today_ts = 'now' | date: '%s' %}
+    {% assign open_dated = "" | split: "," %}
+    {% assign open_undated = "" | split: "," %}
+    {% assign closed_positions = "" | split: "," %}
+
+    {% for pos in site.positions %}
+      {% if pos.deadline %}
+        {% assign deadline_ts = pos.deadline | date: '%s' %}
+        {% if deadline_ts >= today_ts %}
+          {% assign open_dated = open_dated | push: pos %}
+        {% else %}
+          {% assign closed_positions = closed_positions | push: pos %}
+        {% endif %}
+      {% else %}
+        {% assign open_undated = open_undated | push: pos %}
+      {% endif %}
+    {% endfor %}
+
+    {% assign open_dated = open_dated | sort: "deadline" %}
+    {% assign closed_positions = closed_positions | sort: "deadline" | reverse %}
+    {% assign open_positions = open_dated | concat: open_undated %}
+
+    {% if open_positions.size > 0 %}
+    <div class="position-grid">
+      {% for pos in open_positions %}
+        {% include position-card.html position=pos closed=false %}
+      {% endfor %}
+    </div>
+    {% else %}
     <div class="glass" style="border-radius:var(--radius-lg);padding:2.5rem;text-align:center;">
       <svg width="52" height="52" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" style="opacity:0.35;margin:0 auto 1rem;display:block;color:var(--text-muted)">
         <rect x="2" y="7" width="20" height="14" rx="2" ry="2"/>
@@ -43,6 +72,18 @@ permalink: /positions/
         You can also submit a position using the button above.
       </p>
     </div>
+    {% endif %}
+
+    {% if closed_positions.size > 0 %}
+    <details class="positions-closed-details">
+      <summary>{{ closed_positions.size }} closed position{% if closed_positions.size != 1 %}s{% endif %} &mdash; past deadline</summary>
+      <div class="position-grid position-grid-closed">
+        {% for pos in closed_positions %}
+          {% include position-card.html position=pos closed=true %}
+        {% endfor %}
+      </div>
+    </details>
+    {% endif %}
 
     <div class="prose" style="margin-top:3rem;">
       <h2>What kind of positions are listed here?</h2>

--- a/_pages/tag-archive.md
+++ b/_pages/tag-archive.md
@@ -1,7 +1,48 @@
 ---
-layout: page
+layout: default
 title: "Posts by Tag"
 permalink: /tags/
 ---
 
-Browse all posts on the [Posts](/posts/) page.
+<div class="page-hero">
+  <div class="page-hero-overlay"></div>
+  <div class="container">
+    <h1 class="page-hero-title">Posts by Tag</h1>
+    <p class="page-hero-subtitle">Browse CRIYPT community posts grouped by tag.</p>
+  </div>
+</div>
+
+<section class="page-content-section">
+  <div class="container">
+
+    {% if site.tags.size > 0 %}
+    <div class="topic-pills">
+      <span class="filter-label">Jump to:</span>
+      {% for tag in site.tags %}
+        <a href="#{{ tag[0] | slugify }}" class="filter-btn topic-pill">{{ tag[0] }} <span class="tag tag-sm">{{ tag[1].size }}</span></a>
+      {% endfor %}
+    </div>
+
+    {% for tag in site.tags %}
+      {% assign posts_sorted = tag[1] | sort: "date" | reverse %}
+      <div class="archive-group" id="{{ tag[0] | slugify }}">
+        <div class="section-header archive-group-header">
+          <h2 class="section-title archive-group-title">{{ tag[0] }}</h2>
+        </div>
+        <div class="posts-grid posts-grid-full">
+          {% for post in posts_sorted %}
+            {% include post-card.html post=post %}
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+    {% else %}
+    <div class="empty-state glass">
+      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+      <h3>No tags yet</h3>
+      <p>Check back once the community starts publishing posts.</p>
+    </div>
+    {% endif %}
+
+  </div>
+</section>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1644,6 +1644,23 @@ body.modal-open {
 }
 
 /* ============================================================
+   CATEGORY / TAG ARCHIVE
+   ============================================================ */
+.archive-group {
+  margin-bottom: 3rem;
+  scroll-margin-top: 90px;
+}
+
+.archive-group-header {
+  text-align: left;
+  margin-bottom: 1.25rem;
+}
+
+.archive-group-title {
+  font-size: 1.4rem;
+}
+
+/* ============================================================
    POSITIONS PAGE
    ============================================================ */
 .positions-cta {
@@ -1662,6 +1679,115 @@ body.modal-open {
 .positions-cta p {
   max-width: 520px;
   margin: 0 auto 1.5rem;
+}
+
+.position-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.position-card {
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  transition: all var(--transition-slow);
+}
+
+.position-card:hover {
+  border-color: rgba(0,255,136,0.25);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+}
+
+.position-card-closed {
+  opacity: 0.6;
+}
+
+.position-card-closed:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.position-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.9rem;
+}
+
+.position-card-title {
+  font-size: 1.05rem;
+  margin-bottom: 0.25rem;
+}
+
+.position-card-org {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.position-badge-closed {
+  background: rgba(148,163,184,0.15);
+  border: 1px solid rgba(148,163,184,0.3);
+  color: var(--text-dim);
+}
+
+.position-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.position-card-desc {
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+}
+
+.position-card-desc p {
+  margin-bottom: 0;
+}
+
+.position-card-footer {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.positions-closed-details {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.positions-closed-details summary {
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  list-style: none;
+}
+
+.positions-closed-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.positions-closed-details summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.5rem;
+  transition: transform var(--transition);
+}
+
+.positions-closed-details[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.positions-closed-details .position-grid-closed {
+  margin-top: 1.25rem;
+  margin-bottom: 0;
 }
 
 /* ============================================================


### PR DESCRIPTION
…ry/Tag archives, add submission validation CI

- process-submissions.yml: the Add Researcher automation was writing research_areas (list) and lab, but every template that renders a researcher (person-card.html, main.js modal, home.html stats) reads research (comma-joined string) and webpagelab. Fixed the field names so new researcher submissions actually display.
- process-submissions.yml: Add Position now normalizes the deadline into an ISO date when possible (for sorting/expiry) and falls back to a free-text deadline_display for non-parseable input (e.g. "Rolling") instead of writing an unusable string into `deadline`.
- Declared a `positions` collection (output: false) so submitted position files are actually read by Jekyll. positions.md now lists site.positions for real: open positions sorted by nearest deadline first (undated/rolling ones last), with a collapsed "closed" section for expired listings, via a new position-card include.
- categories.md and tags.md now group real posts by site.categories / site.tags with jump-to pills and anchored sections, instead of linking back to /posts/. Post card and post-page tag/category pills now link to these anchors.
- Added a lightweight Ruby CI check (validate-submissions.yml + validate_submissions.rb, stdlib only) that runs on PRs touching names-people.yml, collaborations.yml, or _positions/**: required fields, tag vocabulary, URL/email shape, and duplicate-entry detection — so a malformed auto-generated submission PR fails CI instead of silently merging.

Verified with a local `jekyll build` (via Docker) and by exercising the validator against deliberately broken fixture entries.