### PR TITLE
Add RSS/Atom feed discovery link to head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,7 @@
 <link rel="canonical" href="{{ page.url | absolute_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 <link rel="icon" type="image/png" href="{{ '/assets/images/bio-photo-new-transparent.png' | relative_url }}">
+{% feed_meta %}
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
jekyll-feed was already generating feed.xml, but head.html never advertised it, so feed readers and browsers had no way to discover it. Adds the standard {% feed_meta %} tag, which emits the <link rel="alternate" type="application/atom+xml"> tag pointing at feed.xml.