### PR TITLE
Revamp People page: minimal tiles, rich profile modal, deep links

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-researcher.yml
+++ b/.github/ISSUE_TEMPLATE/add-researcher.yml
@@ -55,6 +55,36 @@ body:
       label: Lab / Group URL (optional)
       placeholder: https://
 
+  - type: input
+    id: email
+    attributes:
+      label: Email ID (optional)
+      placeholder: you@institution.ac.in
+
+  - type: input
+    id: orcid
+    attributes:
+      label: ORCID iD (optional)
+      placeholder: e.g. 0000-0002-1825-0097
+
+  - type: input
+    id: scholar
+    attributes:
+      label: Google Scholar Profile URL (optional)
+      placeholder: https://scholar.google.com/citations?user=...
+
+  - type: input
+    id: dblp
+    attributes:
+      label: DBLP Profile URL (optional)
+      placeholder: https://dblp.org/pid/...
+
+  - type: input
+    id: linkedin
+    attributes:
+      label: LinkedIn Profile URL (optional)
+      placeholder: https://www.linkedin.com/in/...
+
   - type: dropdown
     id: type
     attributes:

--- a/.github/ISSUE_TEMPLATE/edit-researcher.yml
+++ b/.github/ISSUE_TEMPLATE/edit-researcher.yml
@@ -1,0 +1,46 @@
+name: Edit My Profile
+description: Add or update optional profile links on your existing researcher listing
+labels: ["edit-researcher"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Already listed on the [People page](https://cryptography-research-india.github.io/people/)? Use this to add or update your optional profile links. Leave any field blank to leave it unchanged — only fields you fill in will be updated.
+
+  - type: input
+    id: name
+    attributes:
+      label: Full Name (exactly as listed on the People page)
+      placeholder: e.g. Arpita Patra
+    validations:
+      required: true
+
+  - type: input
+    id: email
+    attributes:
+      label: Email ID (optional)
+      placeholder: you@institution.ac.in
+
+  - type: input
+    id: orcid
+    attributes:
+      label: ORCID iD (optional)
+      placeholder: e.g. 0000-0002-1825-0097
+
+  - type: input
+    id: scholar
+    attributes:
+      label: Google Scholar Profile URL (optional)
+      placeholder: https://scholar.google.com/citations?user=...
+
+  - type: input
+    id: dblp
+    attributes:
+      label: DBLP Profile URL (optional)
+      placeholder: https://dblp.org/pid/...
+
+  - type: input
+    id: linkedin
+    attributes:
+      label: LinkedIn Profile URL (optional)
+      placeholder: https://www.linkedin.com/in/...

--- a/.github/scripts/validate_submissions.rb
+++ b/.github/scripts/validate_submissions.rb
@@ -21,6 +21,7 @@ errors = []
 
 URL_RE = %r{\Ahttps?://[^\s]+\z}
 EMAIL_RE = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+ORCID_RE = /\A\d{4}-\d{4}-\d{4}-\d{3}[\dX]\z/
 VALID_SECTOR_TAGS = %w[ACADEMIA INDUSTRY].freeze
 VALID_LOCATION_TAGS = %w[WORKING_IN_INDIA WORKING_ABROAD].freeze
 
@@ -58,11 +59,21 @@ if File.exist?(people_path)
       error(errors, src, "`tags` must include one of #{VALID_LOCATION_TAGS.join(' / ')}")
     end
 
-    %w[webpage webpagelab].each do |key|
+    %w[webpage webpagelab scholar dblp linkedin].each do |key|
       value = person[key]
       if value && !value.to_s.strip.empty? && value.to_s.strip !~ URL_RE
         error(errors, src, "`#{key}` is not a valid http(s) URL: #{value}")
       end
+    end
+
+    email = person["email"]
+    if email && !email.to_s.strip.empty? && email.to_s.strip !~ EMAIL_RE
+      error(errors, src, "`email` is not a valid email address: #{email}")
+    end
+
+    orcid = person["orcid"]
+    if orcid && !orcid.to_s.strip.empty? && orcid.to_s.strip !~ ORCID_RE
+      error(errors, src, "`orcid` is not a valid ORCID iD (expected 0000-0000-0000-000X): #{orcid}")
     end
 
     next if person["name"].to_s.strip.empty?

--- a/.github/workflows/process-submissions.yml
+++ b/.github/workflows/process-submissions.yml
@@ -37,6 +37,11 @@ jobs:
             const rawAreas    = field('Research Areas');
             const webpage     = field('Personal Webpage URL');
             const lab         = field('Lab / Group URL \\(optional\\)');
+            const email       = field('Email ID \\(optional\\)');
+            const orcid       = field('ORCID iD \\(optional\\)');
+            const scholar     = field('Google Scholar Profile URL \\(optional\\)');
+            const dblp        = field('DBLP Profile URL \\(optional\\)');
+            const linkedin    = field('LinkedIn Profile URL \\(optional\\)');
             const sector      = field('Sector');
             const location    = field('Currently based in');
 
@@ -69,6 +74,15 @@ jobs:
             if (researchAreas.length) {
               yaml += `  research: ${researchAreas.join(', ')}\n`;
             }
+            // Optional profile links. `email` is deliberately never rendered as
+            // plaintext in the site's HTML (see _plugins/person_filters.rb) —
+            // that's a rendering-time concern, not a data-storage one, so it's
+            // stored plainly here like everything else.
+            if (email    && email    !== '_No response_') yaml += `  email: ${email}\n`;
+            if (orcid    && orcid    !== '_No response_') yaml += `  orcid: ${orcid}\n`;
+            if (scholar  && scholar  !== '_No response_') yaml += `  scholar: ${scholar}\n`;
+            if (dblp     && dblp     !== '_No response_') yaml += `  dblp: ${dblp}\n`;
+            if (linkedin && linkedin !== '_No response_') yaml += `  linkedin: ${linkedin}\n`;
             yaml += `  tags: [${tags.join(', ')}]\n`;
 
             // Read existing file and append
@@ -98,6 +112,133 @@ jobs:
               ...context.repo,
               title: `Add researcher: ${name}`,
               body: `Submitted via [Issue #${issue.number}](${issue.html_url}) by @${issue.user.login}.\n\n**Entry preview:**\n\`\`\`yaml\n${yaml}\`\`\`\n\n### Checklist\n- [ ] Name and affiliation are correct\n- [ ] Research areas are accurate\n- [ ] Tags are appropriate`,
+              head: branch,
+              base: 'master',
+            });
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: issue.number,
+              body: `✅ Thanks! A PR has been created for review: ${pr.data.html_url}\n\nA maintainer will review and merge it shortly.`,
+            });
+
+  # ── Edit My Profile ─────────────────────────────────────────────────────────
+  edit-researcher:
+    if: contains(github.event.issue.labels.*.name, 'edit-researcher')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Parse issue and update researcher entry
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body  = issue.body || '';
+
+            function field(label) {
+              const re = new RegExp(`### ${label}\\s*\\n+([\\s\\S]*?)(?=\\n### |$)`, 'i');
+              const m  = body.match(re);
+              return m ? m[1].trim() : '';
+            }
+
+            const name = field('Full Name \\(exactly as listed on the People page\\)');
+
+            if (!name) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: '❌ Could not parse the researcher name. Please make sure the Full Name field is filled in.',
+              });
+              return;
+            }
+
+            const updates = {
+              email:    field('Email ID \\(optional\\)'),
+              orcid:    field('ORCID iD \\(optional\\)'),
+              scholar:  field('Google Scholar Profile URL \\(optional\\)'),
+              dblp:     field('DBLP Profile URL \\(optional\\)'),
+              linkedin: field('LinkedIn Profile URL \\(optional\\)'),
+            };
+            for (const key of Object.keys(updates)) {
+              if (!updates[key] || updates[key] === '_No response_') delete updates[key];
+            }
+
+            if (Object.keys(updates).length === 0) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: '❌ No fields to update — please fill in at least one of Email, ORCID, Google Scholar, DBLP, or LinkedIn.',
+              });
+              return;
+            }
+
+            const { data: fileData } = await github.rest.repos.getContent({
+              ...context.repo,
+              path: '_data/names-people.yml',
+              ref: 'master',
+            });
+            const existing = Buffer.from(fileData.content, 'base64').toString('utf8');
+
+            // Locate this researcher's entry block (from its `- name:` line up
+            // to, but not including, the next `- name:` line or end of file).
+            const escaped = name.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const blockRe = new RegExp(`(- name: ${escaped}\\s*\\n)([\\s\\S]*?)(?=\\n- name: |$)`, 'i');
+            const match = existing.match(blockRe);
+
+            if (!match) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: `❌ Could not find a researcher named **${name}** in the directory. Please check that this matches the name exactly as shown on the [People page](https://cryptography-research-india.github.io/people/) — if you're not listed yet, use "Add Yourself" instead.`,
+              });
+              return;
+            }
+
+            const [, header, entryBody] = match;
+            const lines = entryBody.split('\n');
+            const changed = [];
+
+            for (const [key, value] of Object.entries(updates)) {
+              const lineIdx = lines.findIndex(l => l.trim().startsWith(`${key}:`));
+              const newLine = `  ${key}: ${value}`;
+              if (lineIdx !== -1) {
+                lines[lineIdx] = newLine;
+              } else {
+                // New fields are inserted right before `tags:` to match the
+                // field order the Add Researcher automation already writes.
+                const tagsIdx = lines.findIndex(l => l.trim().startsWith('tags:'));
+                if (tagsIdx !== -1) {
+                  lines.splice(tagsIdx, 0, newLine);
+                } else {
+                  let insertAt = lines.length;
+                  while (insertAt > 0 && lines[insertAt - 1].trim() === '') insertAt--;
+                  lines.splice(insertAt, 0, newLine);
+                }
+              }
+              changed.push(key);
+            }
+
+            const updatedBody = lines.join('\n');
+            const newContent = existing.slice(0, match.index) + header + updatedBody
+              + existing.slice(match.index + match[0].length);
+
+            const branch = `submission/edit-researcher-${issue.number}`;
+            const { data: ref } = await github.rest.git.getRef({ ...context.repo, ref: 'heads/master' });
+            await github.rest.git.createRef({ ...context.repo, ref: `refs/heads/${branch}`, sha: ref.object.sha });
+            await github.rest.repos.createOrUpdateFileContents({
+              ...context.repo,
+              path: '_data/names-people.yml',
+              message: `Update researcher profile: ${name}`,
+              content: Buffer.from(newContent).toString('base64'),
+              sha: fileData.sha,
+              branch,
+            });
+
+            const pr = await github.rest.pulls.create({
+              ...context.repo,
+              title: `Update researcher profile: ${name}`,
+              body: `Submitted via [Issue #${issue.number}](${issue.html_url}) by @${issue.user.login}.\n\n**Fields updated:** ${changed.join(', ')}\n\n### Checklist\n- [ ] The submitter is actually this person (or authorized to edit on their behalf)\n- [ ] Updated values are correct`,
               head: branch,
               base: 'master',
             });

--- a/_includes/person-card.html
+++ b/_includes/person-card.html
@@ -1,12 +1,14 @@
 {% assign person = include.person %}
-<article class="person-card glass"
+{% assign slug = person.name | slugify %}
+<a href="{{ '/people/' | relative_url }}#{{ slug }}"
+  class="person-card glass"
   data-tags="{{ person.tags | join: ' ' }}"
   data-name="{{ person.name | downcase }}"
   data-research="{{ person.research | downcase }}"
-  data-person="{{ person | jsonify | escape }}"
-  tabindex="0"
-  role="button"
-  aria-haspopup="dialog">
+  data-slug="{{ slug }}"
+  data-person="{{ person | without_key: 'email' | jsonify | escape }}"
+  {% if person.email %}data-email-enc="{{ person.email | obfuscate_email }}"{% endif %}
+  id="person-{{ slug }}">
   <div class="person-card-inner">
     <div class="person-card-header">
       <div class="person-avatar">
@@ -17,9 +19,7 @@
         {% endif %}
       </div>
       <div class="person-meta">
-        <h3 class="person-name">
-          <a href="{{ person.webpage }}" target="_blank" rel="noopener">{{ person.name }}</a>
-        </h3>
+        <h3 class="person-name">{{ person.name }}</h3>
         <p class="person-designation">{{ person.designation }}</p>
         <p class="person-affiliation">{{ person.affiliation }}</p>
       </div>
@@ -39,24 +39,6 @@
       {% endfor %}
     </div>
 
-    <div class="person-research">
-      {% assign areas = person.research | split: ', ' %}
-      {% for area in areas %}
-        <span class="tag tag-research">{{ area }}</span>
-      {% endfor %}
-    </div>
-
-    <div class="person-card-footer">
-      <a href="{{ person.webpage }}" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
-        Website
-      </a>
-      {% if person.webpagelab %}
-      <a href="{{ person.webpagelab }}" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-        Lab
-      </a>
-      {% endif %}
-    </div>
+    <div class="person-card-hint">View profile →</div>
   </div>
-</article>
+</a>

--- a/_pages/people.md
+++ b/_pages/people.md
@@ -9,10 +9,16 @@ permalink: /people/
   <div class="container">
     <h1 class="page-hero-title">Researchers</h1>
     <p class="page-hero-subtitle">India's cryptography community — spanning academia, industry, and across the globe.</p>
-    <a href="https://github.com/cryptography-research-india/cryptography-research-india.github.io/issues/new?template=add-researcher.yml"
-       class="btn btn-primary" target="_blank" rel="noopener" style="margin-top:1.25rem;">
-      ➕ Add Yourself
-    </a>
+    <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap;margin-top:1.25rem;">
+      <a href="https://github.com/cryptography-research-india/cryptography-research-india.github.io/issues/new?template=add-researcher.yml"
+         class="btn btn-primary" target="_blank" rel="noopener">
+        ➕ Add Yourself
+      </a>
+      <a href="https://github.com/cryptography-research-india/cryptography-research-india.github.io/issues/new?template=edit-researcher.yml"
+         class="btn btn-ghost" target="_blank" rel="noopener">
+        ✏️ Edit My Profile
+      </a>
+    </div>
   </div>
 </div>
 
@@ -68,6 +74,6 @@ permalink: /people/
     </div>
     <div class="person-tags-row" id="person-modal-tags"></div>
     <div class="person-research" id="person-modal-research"></div>
-    <div class="person-card-footer" id="person-modal-footer"></div>
+    <div class="person-card-footer person-modal-links" id="person-modal-footer"></div>
   </div>
 </div>

--- a/_plugins/person_filters.rb
+++ b/_plugins/person_filters.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module Jekyll
+  module PersonFilters
+    # Drops a key from a hash before it's serialized into page HTML — used to
+    # keep `email` out of the `data-person` JSON blob that person-card.html
+    # embeds on every page load. Every other field on a person (webpage,
+    # scholar, dblp, ...) is already public elsewhere by the researcher's own
+    # choice to list it; email is the one field worth not shipping in plain,
+    # always-present, unauthenticated HTML.
+    def without_key(hash, key)
+      return hash unless hash.is_a?(Hash)
+      hash.reject { |k, _| k.to_s == key.to_s }
+    end
+
+    # Base64-encodes a string so it never appears in shipped HTML in a shape
+    # a naive `\S+@\S+` regex harvester would recognize as an email. This is
+    # a speed bump against dumb scrapers, not real security — anything that
+    # executes JS can still decode it client-side (see assets/js/main.js,
+    # which only does so at the moment a person's modal is opened).
+    def obfuscate_email(input)
+      return "" if input.nil? || input.to_s.strip.empty?
+
+      Base64.strict_encode64(input.to_s.strip)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::PersonFilters)

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -670,10 +670,12 @@ p { color: var(--text-muted); }
    PERSON CARD
    ============================================================ */
 .person-card {
+  display: block;
   border-radius: var(--radius-lg);
   transition: all var(--transition-slow);
   overflow: hidden;
   animation: fadeInUp 0.5s ease both;
+  cursor: pointer;
 }
 
 .person-card:hover {
@@ -736,16 +738,6 @@ p { color: var(--text-muted); }
   margin-bottom: 0.2rem;
 }
 
-.person-name a {
-  color: var(--text);
-  text-decoration: none;
-  transition: color var(--transition);
-}
-
-.person-name a:hover {
-  color: var(--green);
-}
-
 .person-designation {
   font-size: 0.82rem;
   color: var(--text-muted);
@@ -779,6 +771,25 @@ p { color: var(--text-muted); }
   padding-top: 0.5rem;
   border-top: 1px solid var(--border);
   margin-top: auto;
+}
+
+.person-modal-links {
+  gap: 0.6rem;
+}
+
+.person-card-hint {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity var(--transition), transform var(--transition);
+}
+
+.person-card:hover .person-card-hint,
+.person-card:focus-visible .person-card-hint {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* ============================================================
@@ -881,10 +892,6 @@ p { color: var(--text-muted); }
 
 #search-people:focus {
   border-color: rgba(0,255,136,0.35);
-}
-
-.person-card {
-  cursor: pointer;
 }
 
 /* ============================================================

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -217,7 +217,19 @@
       return '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>';
     }
 
-    function openModal(person, avatarBackground) {
+    function linkedinIcon() {
+      return '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>';
+    }
+
+    function copyIcon() {
+      return '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+    }
+
+    function checkIcon() {
+      return '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>';
+    }
+
+    function openModal(person, avatarBackground, card) {
       modalName.textContent = person.name || '';
       modalDesignation.textContent = person.designation || '';
       modalAffiliation.textContent = person.affiliation || '';
@@ -255,14 +267,93 @@
         modalResearch.appendChild(el);
       });
 
-      var footerHtml = '';
-      if (person.webpage) {
-        footerHtml += '<a href="' + person.webpage + '" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">' + websiteIcon() + ' Website</a>';
+      modalFooter.innerHTML = '';
+
+      function addLink(href, label, iconSvg) {
+        if (!href) return;
+        var a = document.createElement('a');
+        a.href = href;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.className = 'btn btn-ghost btn-sm';
+        a.innerHTML = iconSvg + ' ' + label;
+        modalFooter.appendChild(a);
       }
-      if (person.webpagelab) {
-        footerHtml += '<a href="' + person.webpagelab + '" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">' + labIcon() + ' Lab</a>';
+
+      addLink(person.webpage, 'Website', websiteIcon());
+      addLink(person.webpagelab, 'Lab', labIcon());
+      addLink(person.scholar, 'Google Scholar', websiteIcon());
+      addLink(person.dblp, 'DBLP', websiteIcon());
+      if (person.orcid) {
+        var orcidHref = /^https?:\/\//.test(person.orcid) ? person.orcid : 'https://orcid.org/' + person.orcid;
+        addLink(orcidHref, 'ORCID', websiteIcon());
       }
-      modalFooter.innerHTML = footerHtml;
+      addLink('https://eprint.iacr.org/search?q=' + encodeURIComponent(person.name || ''), 'ePrint', websiteIcon());
+      addLink(person.linkedin, 'LinkedIn', linkedinIcon());
+
+      // Email is deliberately never present in `person` — it's excluded from
+      // the data-person JSON blob (see person-card.html and
+      // _plugins/person_filters.rb) so it never sits in plain HTML. It's
+      // decoded here, only at the moment this specific modal opens, from the
+      // card's own base64 attribute, and rendered as copy-to-clipboard rather
+      // than a mailto: link or visible text.
+      var emailEnc = card ? card.dataset.emailEnc : '';
+      if (emailEnc) {
+        var email = '';
+        try { email = atob(emailEnc); } catch (e) { email = ''; }
+        if (email) {
+          var copyBtn = document.createElement('button');
+          copyBtn.type = 'button';
+          copyBtn.className = 'btn btn-ghost btn-sm';
+          copyBtn.innerHTML = copyIcon() + ' Copy Email';
+
+          function showCopied() {
+            copyBtn.innerHTML = checkIcon() + ' Copied!';
+            setTimeout(function () {
+              copyBtn.innerHTML = copyIcon() + ' Copy Email';
+            }, 1800);
+          }
+
+          // Fallback for browsers/contexts that reject the async Clipboard
+          // API (no permission granted, insecure context, older browser).
+          // execCommand is deprecated but still works synchronously inside a
+          // real user gesture, which this click handler always is.
+          function fallbackCopy() {
+            var ta = document.createElement('textarea');
+            ta.value = email;
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.focus();
+            ta.select();
+            var ok = false;
+            try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+            document.body.removeChild(ta);
+            return ok;
+          }
+
+          copyBtn.addEventListener('click', function () {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+              navigator.clipboard.writeText(email).then(showCopied, function () {
+                if (fallbackCopy()) {
+                  showCopied();
+                } else {
+                  copyBtn.innerHTML = 'Copy failed — ' + email;
+                }
+              });
+            } else if (fallbackCopy()) {
+              showCopied();
+            } else {
+              copyBtn.innerHTML = 'Copy failed — ' + email;
+            }
+          });
+          modalFooter.appendChild(copyBtn);
+        }
+      }
+
+      if (card && card.dataset.slug) {
+        history.replaceState(null, '', '#' + card.dataset.slug);
+      }
 
       lastFocused = document.activeElement;
       modalOverlay.classList.add('open');
@@ -273,33 +364,37 @@
     function closeModal() {
       modalOverlay.classList.remove('open');
       document.body.classList.remove('modal-open');
+      if (location.hash) {
+        history.replaceState(null, '', location.pathname + location.search);
+      }
       if (lastFocused && typeof lastFocused.focus === 'function') lastFocused.focus();
     }
 
-    personCards.forEach(function (card) {
-      function trigger() {
-        var raw = card.dataset.person;
-        if (!raw) return;
-        var person;
-        try {
-          person = JSON.parse(raw);
-        } catch (e) {
-          return;
-        }
-        var avatar = card.querySelector('.person-avatar');
-        openModal(person, avatar ? avatar.style.background : '');
+    function openCardModal(card) {
+      var raw = card.dataset.person;
+      if (!raw) return;
+      var person;
+      try {
+        person = JSON.parse(raw);
+      } catch (e) {
+        return;
       }
+      var avatar = card.querySelector('.person-avatar');
+      openModal(person, avatar ? avatar.style.background : '', card);
+    }
 
+    // Each card is a real <a href="/people/#slug"> (see person-card.html) so
+    // it works with no JS at all — right-click/middle-click/ctrl-click all
+    // behave exactly as a link should, and on pages without a modal (the
+    // homepage's featured grid) it's just a normal navigation to that
+    // person's deep-linked profile. Here, where a modal exists, the click is
+    // intercepted to open it in place instead of navigating away. Native
+    // anchor behavior already fires this same 'click' handler for Enter, so
+    // no separate keydown handling is needed.
+    personCards.forEach(function (card) {
       card.addEventListener('click', function (e) {
-        if (e.target.closest('a')) return;
-        trigger();
-      });
-
-      card.addEventListener('keydown', function (e) {
-        if ((e.key === 'Enter' || e.key === ' ') && !e.target.closest('a')) {
-          e.preventDefault();
-          trigger();
-        }
+        e.preventDefault();
+        openCardModal(card);
       });
     });
 
@@ -312,6 +407,19 @@
     document.addEventListener('keydown', function (e) {
       if (e.key === 'Escape' && modalOverlay.classList.contains('open')) closeModal();
     });
+
+    // Deep-linkable profiles: /people/#slug (or the homepage's featured
+    // grid, which uses the same cards) opens that researcher's modal
+    // directly on load.
+    if (location.hash) {
+      var initialSlug = decodeURIComponent(location.hash.slice(1));
+      for (var ci = 0; ci < personCards.length; ci++) {
+        if (personCards[ci].dataset.slug === initialSlug) {
+          openCardModal(personCards[ci]);
+          break;
+        }
+      }
+    }
   }
 
   /* ============================================================


### PR DESCRIPTION
Tiles now show only avatar, name, designation, affiliation, and the status badges. Everything else moves into the detail modal on click: full research-area tags plus a new Links row for whichever of Website, Lab, Google Scholar, DBLP, ORCID, ePrint (computed search link), LinkedIn, and Email exist for that person.

Each card is now a real <a href="/people/#slug"> instead of an <article role="button">, so it degrades gracefully with no JS, supports the usual link affordances (open in new tab, etc.), and gives every researcher a shareable profile URL. On a page with the modal (people.md), the click is intercepted to open it in place; on pages without one (the homepage's featured grid), it's a normal navigation to that deep link, which then auto-opens the modal on arrival.

New optional profile fields (email, orcid, scholar, dblp, linkedin) are wired end-to-end: add-researcher.yml issue template, the add-researcher automation job, and validate_submissions.rb (email/ ORCID/URL shape checks). A new edit-researcher.yml template + PR automation job lets already-listed researchers patch their existing entry with these fields after the fact, since otherwise nobody already on the site would have a way to add them.

Email gets different treatment from every other field: it's deliberately excluded from the data-person JSON blob every card already carries (see _plugins/person_filters.rb's without_key filter), and is instead base64-encoded into its own attribute (obfuscate_email filter) that's only decoded client-side at the moment a person's modal opens, rendered as copy-to-clipboard rather than mailto: or visible text. This is a speed bump against naive regex email harvesters scanning static HTML, not real security, and is documented as such in both the plugin and main.js. The copy button falls back from the async Clipboard API to execCommand, and finally to showing the address as plain text if both fail, rather than silently doing nothing.