### PR TITLE
Fix broken avatar-initials fallback for photoless researchers

### DIFF
--- a/_includes/person-card.html
+++ b/_includes/person-card.html
@@ -15,7 +15,7 @@
         {% if person.photo %}
           <img src="{{ person.photo | relative_url }}" alt="{{ person.name }}" class="avatar-photo" loading="lazy">
         {% else %}
-          <span class="avatar-initials">{{ person.name | split: ' ' | map: 'first' | join: '' | slice: 0, 2 | upcase }}</span>
+          <span class="avatar-initials">{{ person.name | initials }}</span>
         {% endif %}
       </div>
       <div class="person-meta">

--- a/_plugins/person_filters.rb
+++ b/_plugins/person_filters.rb
@@ -25,6 +25,19 @@ module Jekyll
 
       Base64.strict_encode64(input.to_s.strip)
     end
+
+    # Returns up to the first 2 initials from a name, e.g. "Arpita Patra" ->
+    # "AP". `split(' ') | map: 'first' | join` doesn't work in Liquid — `map`
+    # pulls a hash/object property named "first" off each item, it doesn't
+    # take the first character of a string — so that chain silently produces
+    # an empty string for every person without a `photo`. This mirrors the
+    # (correct) equivalent already used client-side in the researcher modal's
+    # getInitials() in assets/js/main.js.
+    def initials(name)
+      return "" if name.nil? || name.to_s.strip.empty?
+
+      name.to_s.split(/\s+/).reject(&:empty?).map { |word| word[0] }.join.slice(0, 2).to_s.upcase
+    end
   end
 end
 


### PR DESCRIPTION
person-card.html's initials fallback was:
  person.name | split: ' ' | map: 'first' | join: '' | slice: 0, 2 | upcase
`map: 'first'` pulls a hash property named "first" off each item — it doesn't take the first character of a string — so this silently rendered an empty avatar for any researcher without a `photo` field.

Adds an `initials` filter to _plugins/person_filters.rb that mirrors the already-correct client-side getInitials() in assets/js/main.js, and uses it in person-card.html instead.

This didn't show up in practice because nearly every current entry in names-people.yml already has a photo, but it breaks visibly (a blank circle) for any newly-submitted researcher, since photo isn't a field on the Add Researcher form — photos only arrive later via the separate fetch-researcher-photos.yml bot.