### PR TITLE
Add topic filtering to the People page

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-researcher.yml
+++ b/.github/ISSUE_TEMPLATE/add-researcher.yml
@@ -43,6 +43,26 @@ body:
     validations:
       required: true
 
+  - type: checkboxes
+    id: topics
+    attributes:
+      label: Topics (optional)
+      description: Select all that apply — used to power topic filtering on the People page
+      options:
+        - label: Multi-Party Computation (MPC)
+        - label: Zero-Knowledge Proofs (ZKP)
+        - label: Fully Homomorphic Encryption (FHE)
+        - label: Public Key Cryptography
+        - label: Symmetric Cryptography
+        - label: Post-Quantum Cryptography (PQC)
+        - label: Privacy-Preserving ML (PPML)
+        - label: Blockchain / Distributed Ledger
+        - label: Hardware Security / TEEs
+        - label: Applied Cryptography
+        - label: Theoretical Cryptography
+        - label: Security Protocols
+        - label: Coding Theory / Information Theory
+
   - type: input
     id: webpage
     attributes:

--- a/.github/ISSUE_TEMPLATE/collaboration-request.yml
+++ b/.github/ISSUE_TEMPLATE/collaboration-request.yml
@@ -50,6 +50,7 @@ body:
         - label: Applied Cryptography
         - label: Theoretical Cryptography
         - label: Security Protocols
+        - label: Coding Theory / Information Theory
 
   - type: dropdown
     id: seeking

--- a/.github/ISSUE_TEMPLATE/edit-researcher.yml
+++ b/.github/ISSUE_TEMPLATE/edit-researcher.yml
@@ -15,6 +15,26 @@ body:
     validations:
       required: true
 
+  - type: checkboxes
+    id: topics
+    attributes:
+      label: Topics (optional)
+      description: Select any topics to set/replace your topics list. Leave all unchecked to leave your topics unchanged.
+      options:
+        - label: Multi-Party Computation (MPC)
+        - label: Zero-Knowledge Proofs (ZKP)
+        - label: Fully Homomorphic Encryption (FHE)
+        - label: Public Key Cryptography
+        - label: Symmetric Cryptography
+        - label: Post-Quantum Cryptography (PQC)
+        - label: Privacy-Preserving ML (PPML)
+        - label: Blockchain / Distributed Ledger
+        - label: Hardware Security / TEEs
+        - label: Applied Cryptography
+        - label: Theoretical Cryptography
+        - label: Security Protocols
+        - label: Coding Theory / Information Theory
+
   - type: input
     id: email
     attributes:

--- a/.github/scripts/validate_submissions.rb
+++ b/.github/scripts/validate_submissions.rb
@@ -7,7 +7,7 @@
 # data (e.g. a missing required field, a bad URL, or a duplicate entry).
 #
 # Checks, per source:
-#   _data/names-people.yml   - required keys, tag vocabulary, URL shape, dup names
+#   _data/names-people.yml   - required keys, tag/topic vocabulary, URL shape, dup names
 #   _data/collaborations.yml - required keys, email shape, URL shape, dup (name+topic)
 #   _positions/*.md          - required front matter keys, URL shape, dup (title+org)
 #
@@ -24,6 +24,13 @@ EMAIL_RE = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
 ORCID_RE = /\A\d{4}-\d{4}-\d{4}-\d{3}[\dX]\z/
 VALID_SECTOR_TAGS = %w[ACADEMIA INDUSTRY].freeze
 VALID_LOCATION_TAGS = %w[WORKING_IN_INDIA WORKING_ABROAD].freeze
+
+topics_path = File.join(ROOT, "_data/topics.yml")
+VALID_TOPIC_CODES = if File.exist?(topics_path)
+                      (YAML.safe_load_file(topics_path) || []).map { |t| t["code"] }
+                    else
+                      []
+                    end.freeze
 
 def error(errors, source, message)
   errors << "#{source}: #{message}"
@@ -74,6 +81,18 @@ if File.exist?(people_path)
     orcid = person["orcid"]
     if orcid && !orcid.to_s.strip.empty? && orcid.to_s.strip !~ ORCID_RE
       error(errors, src, "`orcid` is not a valid ORCID iD (expected 0000-0000-0000-000X): #{orcid}")
+    end
+
+    topics = person["topics"]
+    if topics
+      unless topics.is_a?(Array)
+        error(errors, src, "`topics` must be a list")
+      else
+        unknown = topics - VALID_TOPIC_CODES
+        if unknown.any?
+          error(errors, src, "`topics` has unknown code(s) #{unknown.join(', ')} — must be one of #{VALID_TOPIC_CODES.join(', ')}")
+        end
+      end
     end
 
     next if person["name"].to_s.strip.empty?

--- a/.github/workflows/process-submissions.yml
+++ b/.github/workflows/process-submissions.yml
@@ -31,10 +31,42 @@ jobs:
               return m ? m[1].trim() : '';
             }
 
+            // Parse checked options from a `type: checkboxes` section.
+            function checkedOptions(sectionLabel) {
+              const re = new RegExp(`### ${sectionLabel}\\s*\\n+([\\s\\S]*?)(?=\\n### |$)`, 'i');
+              const m = body.match(re);
+              if (!m) return [];
+              const checked = [];
+              for (const line of m[1].split('\n')) {
+                const cm = line.match(/^- \[x\] (.+)/i);
+                if (cm) checked.push(cm[1].trim());
+              }
+              return checked;
+            }
+
+            // Must stay in sync with _data/topics.yml and the checkbox labels
+            // in add-researcher.yml / edit-researcher.yml.
+            const TOPIC_CODE_BY_LABEL = {
+              'Multi-Party Computation (MPC)': 'MPC',
+              'Zero-Knowledge Proofs (ZKP)': 'ZKP',
+              'Fully Homomorphic Encryption (FHE)': 'FHE',
+              'Public Key Cryptography': 'PKC',
+              'Symmetric Cryptography': 'SYMMETRIC',
+              'Post-Quantum Cryptography (PQC)': 'PQC',
+              'Privacy-Preserving ML (PPML)': 'PPML',
+              'Blockchain / Distributed Ledger': 'BLOCKCHAIN',
+              'Hardware Security / TEEs': 'HARDWARE',
+              'Applied Cryptography': 'APPLIED',
+              'Theoretical Cryptography': 'THEORETICAL',
+              'Security Protocols': 'PROTOCOLS',
+              'Coding Theory / Information Theory': 'CODING',
+            };
+
             const name        = field('Full Name');
             const designation = field('Designation');
             const affiliation = field('Affiliation');
             const rawAreas    = field('Research Areas');
+            const topicCodes  = checkedOptions('Topics \\(optional\\)').map(label => TOPIC_CODE_BY_LABEL[label]).filter(Boolean);
             const webpage     = field('Personal Webpage URL');
             const lab         = field('Lab / Group URL \\(optional\\)');
             const email       = field('Email ID \\(optional\\)');
@@ -83,6 +115,9 @@ jobs:
             if (scholar  && scholar  !== '_No response_') yaml += `  scholar: ${scholar}\n`;
             if (dblp     && dblp     !== '_No response_') yaml += `  dblp: ${dblp}\n`;
             if (linkedin && linkedin !== '_No response_') yaml += `  linkedin: ${linkedin}\n`;
+            if (topicCodes.length) {
+              yaml += `  topics: [${topicCodes.join(', ')}]\n`;
+            }
             yaml += `  tags: [${tags.join(', ')}]\n`;
 
             // Read existing file and append
@@ -142,6 +177,37 @@ jobs:
               return m ? m[1].trim() : '';
             }
 
+            // Parse checked options from a `type: checkboxes` section.
+            function checkedOptions(sectionLabel) {
+              const re = new RegExp(`### ${sectionLabel}\\s*\\n+([\\s\\S]*?)(?=\\n### |$)`, 'i');
+              const m = body.match(re);
+              if (!m) return [];
+              const checked = [];
+              for (const line of m[1].split('\n')) {
+                const cm = line.match(/^- \[x\] (.+)/i);
+                if (cm) checked.push(cm[1].trim());
+              }
+              return checked;
+            }
+
+            // Must stay in sync with _data/topics.yml and the checkbox labels
+            // in add-researcher.yml / edit-researcher.yml.
+            const TOPIC_CODE_BY_LABEL = {
+              'Multi-Party Computation (MPC)': 'MPC',
+              'Zero-Knowledge Proofs (ZKP)': 'ZKP',
+              'Fully Homomorphic Encryption (FHE)': 'FHE',
+              'Public Key Cryptography': 'PKC',
+              'Symmetric Cryptography': 'SYMMETRIC',
+              'Post-Quantum Cryptography (PQC)': 'PQC',
+              'Privacy-Preserving ML (PPML)': 'PPML',
+              'Blockchain / Distributed Ledger': 'BLOCKCHAIN',
+              'Hardware Security / TEEs': 'HARDWARE',
+              'Applied Cryptography': 'APPLIED',
+              'Theoretical Cryptography': 'THEORETICAL',
+              'Security Protocols': 'PROTOCOLS',
+              'Coding Theory / Information Theory': 'CODING',
+            };
+
             const name = field('Full Name \\(exactly as listed on the People page\\)');
 
             if (!name) {
@@ -153,6 +219,8 @@ jobs:
               return;
             }
 
+            const topicCodes = checkedOptions('Topics \\(optional\\)').map(label => TOPIC_CODE_BY_LABEL[label]).filter(Boolean);
+
             const updates = {
               email:    field('Email ID \\(optional\\)'),
               orcid:    field('ORCID iD \\(optional\\)'),
@@ -162,6 +230,13 @@ jobs:
             };
             for (const key of Object.keys(updates)) {
               if (!updates[key] || updates[key] === '_No response_') delete updates[key];
+            }
+            // Only set/replace topics if at least one box was checked — an
+            // entirely unchecked section means "leave topics unchanged",
+            // matching the blank-means-unchanged convention every other
+            // field here already uses.
+            if (topicCodes.length) {
+              updates.topics = `[${topicCodes.join(', ')}]`;
             }
 
             if (Object.keys(updates).length === 0) {

--- a/.github/workflows/validate-submissions.yml
+++ b/.github/workflows/validate-submissions.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "_data/names-people.yml"
       - "_data/collaborations.yml"
+      - "_data/topics.yml"
       - "_positions/**"
 
 jobs:

--- a/_data/names-people.yml
+++ b/_data/names-people.yml
@@ -5,92 +5,104 @@
   webpage: https://ajithsuresh.github.io
   webpagelab: https://www.tii.ae/team/dr-ajith-suresh
   research: Secure Multiparty Computation, Privacy-preserving Machine Learning
+  topics: [MPC, PPML]
   tags: [INDUSTRY, WORKING_ABROAD]
-  
+
 - name: Arpita Patra
   designation: Associate Professor
   affiliation: Indian Institute of Science Bangalore (IISc)
   webpage: https://www.csa.iisc.ac.in/~arpita/
   webpagelab: https://cris.csa.iisc.ac.in
   research: Secure Multiparty Computation
+  topics: [MPC]
   tags: [ACADEMIA, WORKING_IN_INDIA]
-  
+
 - name: Ashish Choudhury
   designation: Associate Professor
   affiliation: Indian Institute of Information Technology Bangalore (IIITB)
   webpage: https://sites.google.com/view/ashish-choudhury
   webpagelab: https://www.iiitb.ac.in/faculty/ashish-choudhury
   research: Secure Multiparty Computation
+  topics: [MPC]
   tags: [ACADEMIA, WORKING_IN_INDIA]
-  
+
 - name: Bhavana Kanukurthi
   designation: Associate Professor
   affiliation: Indian Institute of Science Bangalore (IISc)
   webpage: https://www.csa.iisc.ac.in/~bhavana/
   webpagelab: https://www.csa.iisc.ac.in/~crysp/
   research: Non-malleable Codes, Information Theory
+  topics: [THEORETICAL, CODING, MPC]
   tags: [ACADEMIA, WORKING_IN_INDIA]
-  
+
 - name: Chaya Ganesh
   designation: Assistant Professor
   affiliation: Indian Institute of Science Bangalore (IISc)
   webpage: https://www.csa.iisc.ac.in/~chaya/
   webpagelab: https://www.csa.iisc.ac.in/~chaya/
   research: Cryptography, Zero-knowledge Proofs
+  topics: [ZKP, THEORETICAL]
   tags: [ACADEMIA, WORKING_IN_INDIA]
-  
+
 - name: Debdeep Mukhopadhyay
   designation: Institute Chair Professor
   affiliation: Indian Institute of Technology Kharagpur
   webpage: https://sites.google.com/view/debdeepmukhopadhyay/home
   webpagelab: http://cse.iitkgp.ac.in/resgrp/seal/
   research: Cryptography, Hardware Security
+  topics: [HARDWARE]
   tags: [ACADEMIA, WORKING_IN_INDIA]
-  
+
 - name: Divya Gupta
   designation: Principal Researcher
   affiliation: Micrososft Research India
   webpage: https://www.microsoft.com/en-us/research/people/digup/
   research: Applied Cryptography, Secure Multi-party Computation, Blockchain
+  topics: [APPLIED, MPC, BLOCKCHAIN]
   tags: [INDUSTRY, WORKING_IN_INDIA]
-  
+
 - name: Divya Ravi
   designation: Assistant Professor
   affiliation: University of Amsterdam, Netherlands
   webpage: https://sites.google.com/site/divyaraviiisc/
   webpagelab: https://ivi.fnwi.uva.nl/tcs/
   research: Secure Multi-party Computation, Distributed Computing
+  topics: [MPC, THEORETICAL]
   tags: [ACADEMIA, WORKING_ABROAD]
-  
+
 - name: Manoj M. Prabhakaran
   designation: Professor
   affiliation: Indian Institute of Technology Bombay (IITB)
   webpage: https://www.cse.iitb.ac.in/~mp/
   webpagelab: https://trustlab.iitb.ac.in
   research: Theoretical and Applied Cryptography
+  topics: [THEORETICAL, APPLIED]
   tags: [ACADEMIA, WORKING_IN_INDIA]
-  
+
 - name: Mridul Nandi
   designation: Professor
   affiliation: Indian Statistical Institute Kolkata
   webpage: https://www.isical.ac.in/~mridul/
   webpagelab: https://www.isical.ac.in/~asu/
   research: Symmetric Cryptography
+  topics: [SYMMETRIC]
   tags: [ACADEMIA, WORKING_IN_INDIA]
-  
+
 - name: Nishanth Chandran
   designation: Principal Researcher
   affiliation: Micrososft Research India
   webpage: https://www.microsoft.com/en-us/research/people/nichandr/
   research: Applied Cryptography, Confidential Computing, Secure Computation
+  topics: [APPLIED, MPC]
   tags: [INDUSTRY, WORKING_IN_INDIA]
-  
+
 - name: Nishat Koti
   designation: Cryptography Researcher
   affiliation: Aztec Labs, UK
   webpage: https://sites.google.com/view/nishatskoti
   webpagelab: https://www.aztec-labs.com/team
   research: Secure Multi-party Computation, Privacy-preserving Machine Learning
+  topics: [MPC, PPML]
   tags: [INDUSTRY, WORKING_ABROAD]
 
 - name: Nitin Singh
@@ -98,53 +110,60 @@
   affiliation: IBM Research India
   webpage: https://www.linkedin.com/in/nitin-singh-36b92796
   research: Applied Cryptography, Blockchain
+  topics: [APPLIED, BLOCKCHAIN]
   tags: [INDUSTRY, WORKING_IN_INDIA]
-  
+
 - name: Pankaj Dayama
   designation: Senior Technical Staff Member
   affiliation: IBM Research India
   webpage: https://research.ibm.com/people/pankaj-dayama
   research: Applied Cryptography, Blockchain
+  topics: [APPLIED, BLOCKCHAIN]
   tags: [INDUSTRY, WORKING_IN_INDIA]
-  
+
 - name: Pradeep Mishra
   designation: Senior FHE Researcher
   affiliation: Technology Innovation Institute (TII), UAE
   webpage: https://www.linkedin.com/in/dr-pradeep-mishra-635019157/
   webpagelab: https://www.tii.ae/team/dr-pradeep-mishra
   research: Homomorphic Encryption
+  topics: [FHE]
   tags: [INDUSTRY, WORKING_ABROAD]
-  
+
 - name: Pratik Sarkar
   designation: Research Scientist
   affiliation: Supra Research
   webpage: https://sites.google.com/view/pratiksarkar/welcome
   webpagelab: https://supra.com
   research: Secure Multi-party Computation, Zero-Knowledge Proofs, Blockchain
+  topics: [MPC, ZKP, BLOCKCHAIN]
   tags: [INDUSTRY, WORKING_IN_INDIA]
-  
+
 - name: Pratyay Mukherjee
   designation: Senior Director of Research
   affiliation: Supra Research
   webpage: https://pratyay.net
   webpagelab: https://supra.com
   research: Cryptography in Payment and Blockchain
+  topics: [BLOCKCHAIN, APPLIED]
   tags: [INDUSTRY, WORKING_IN_INDIA]
-  
+
 - name: Rahul Rachuri
   designation: Staff Research Scientist
   affiliation: Visa Research
   webpage: https://rahulrachuri.github.io
   webpagelab: https://usa.visa.com/about-visa/visa-research/people.html
   research: Secure Multiparty Computation, Privacy-preserving Machine Learning
+  topics: [MPC, PPML]
   tags: [INDUSTRY, WORKING_ABROAD]
-  
+
 - name: Sameer Wagh
   designation: Senior Research Engineer
   affiliation: OpenMined
   webpage: https://snwagh.github.io/
   webpagelab: https://openmined.org/
   research: Secure Multiparty Computation, Homomorphic Encryption, Federated Learning
+  topics: [MPC, FHE, PPML]
   tags: [INDUSTRY, WORKING_ABROAD]
 
 - name: Shweta Agrawal
@@ -153,29 +172,33 @@
   webpage: https://www.cse.iitm.ac.in/~shwetaag/
   webpagelab: https://cystar.iitm.ac.in
   research: Theoretical Cryptography, Post-quantum cryptography
+  topics: [THEORETICAL, PQC]
   tags: [ACADEMIA, WORKING_IN_INDIA]
-  
+
 - name: Sikhar Patranabis
   designation: Research Scientist
   affiliation: IBM Research India
   webpage: https://sites.google.com/site/sikharpatranabis/home
   research: Theoretical and Applied Cryptography
+  topics: [THEORETICAL, APPLIED]
   tags: [INDUSTRY, WORKING_IN_INDIA]
-  
+
 - name: Somitra Sanadhya
   designation: Professor
   affiliation: Indian Institute of Technology Jodhpur
   webpage: https://sites.google.com/view/somitra/
   webpagelab: https://sites.google.com/view/somitra/
   research: Cryptology and Security, Blockchain
+  topics: [SYMMETRIC, BLOCKCHAIN]
   tags: [ACADEMIA, WORKING_IN_INDIA]
-  
+
 - name: Sruthi Sekhar
   designation: Assistant Professor
   affiliation: Indian Institute of Technology Bombay (IITB)
   webpage: https://sruthisekar.wordpress.com
   webpagelab: https://trustlab.iitb.ac.in/
   research: Cryptography
+  topics: [THEORETICAL, MPC]
   tags: [ACADEMIA, WORKING_IN_INDIA]
 
 - name: Suvradip Chakraborty
@@ -184,12 +207,14 @@
   webpage: https://sites.google.com/view/suvradip/
   webpagelab: https://usa.visa.com/about-visa/visa-research/people.html
   research: Public-Key Cryptography
+  topics: [PKC]
   tags: [INDUSTRY, WORKING_ABROAD]
-  
+
 - name: Yashvanth Kondi
   designation: Principal Scientist
   affiliation: Silence Laboratories
   webpage: https://www.ykondi.net
   webpagelab: https://www.silencelaboratories.com
   research: Secure Multiparty Computation, Zero-knowledge proofs
+  topics: [MPC, ZKP]
   tags: [INDUSTRY, WORKING_ABROAD]

--- a/_data/topics.yml
+++ b/_data/topics.yml
@@ -1,0 +1,32 @@
+# Controlled vocabulary for researcher topic filtering on the People page.
+# Reused (and, for CODING, extended) from the Research Areas checkboxes in
+# .github/ISSUE_TEMPLATE/collaboration-request.yml — keep both lists in sync
+# when adding or renaming a topic. `code` must be a single token (no spaces)
+# since it's used as a space-delimited filter token in data-topics.
+---
+- code: MPC
+  label: "Multi-Party Computation (MPC)"
+- code: ZKP
+  label: "Zero-Knowledge Proofs (ZKP)"
+- code: FHE
+  label: "Fully Homomorphic Encryption (FHE)"
+- code: PKC
+  label: "Public Key Cryptography"
+- code: SYMMETRIC
+  label: "Symmetric Cryptography"
+- code: PQC
+  label: "Post-Quantum Cryptography (PQC)"
+- code: PPML
+  label: "Privacy-Preserving ML (PPML)"
+- code: BLOCKCHAIN
+  label: "Blockchain / Distributed Ledger"
+- code: HARDWARE
+  label: "Hardware Security / TEEs"
+- code: APPLIED
+  label: "Applied Cryptography"
+- code: THEORETICAL
+  label: "Theoretical Cryptography"
+- code: PROTOCOLS
+  label: "Security Protocols"
+- code: CODING
+  label: "Coding Theory / Information Theory"

--- a/_includes/person-card.html
+++ b/_includes/person-card.html
@@ -2,7 +2,7 @@
 {% assign slug = person.name | slugify %}
 <a href="{{ '/people/' | relative_url }}#{{ slug }}"
   class="person-card glass"
-  data-tags="{{ person.tags | join: ' ' }}"
+  data-tags="{{ person.tags | join: ' ' }}{% if person.topics %} {{ person.topics | join: ' ' }}{% endif %}"
   data-name="{{ person.name | downcase }}"
   data-research="{{ person.research | downcase }}"
   data-slug="{{ slug }}"

--- a/_pages/people.md
+++ b/_pages/people.md
@@ -48,6 +48,17 @@ permalink: /people/
       <span class="people-count" id="people-count"></span>
     </div>
 
+    {% if site.data.topics.size > 0 %}
+    <details class="topic-filter-details">
+      <summary>Filter by topic</summary>
+      <div class="topic-filter-pills">
+        {% for topic in site.data.topics %}
+          <button class="filter-btn" data-filter="{{ topic.code }}">{{ topic.label }}</button>
+        {% endfor %}
+      </div>
+    </details>
+    {% endif %}
+
     <!-- People Grid -->
     <div class="people-grid" id="people-grid">
       {% for person in site.data.names-people %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -866,6 +866,40 @@ p { color: var(--text-muted); }
   color: var(--cyan);
 }
 
+.topic-filter-details {
+  margin-bottom: 2rem;
+}
+
+.topic-filter-details summary {
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  list-style: none;
+}
+
+.topic-filter-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.topic-filter-details summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.5rem;
+  transition: transform var(--transition);
+}
+
+.topic-filter-details[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.topic-filter-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
 .people-count {
   margin-left: auto;
   font-family: var(--font-mono);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -88,6 +88,17 @@
       ['ACADEMIA', 'INDUSTRY'],
       ['WORKING_IN_INDIA', 'WORKING_ABROAD']
     ];
+
+    // Topic codes (MPC, ZKP, ...) form their own OR-group, read directly off
+    // whatever buttons are actually on the page — the canonical list lives
+    // in _data/topics.yml, not duplicated here.
+    var topicFilterBtns = document.querySelectorAll('.topic-filter-pills [data-filter]');
+    if (topicFilterBtns.length) {
+      FILTER_GROUPS.push(Array.prototype.map.call(topicFilterBtns, function (b) {
+        return b.dataset.filter;
+      }));
+    }
+
     var activeFilters = new Set();
 
     // Assign gradient colors to avatars based on index


### PR DESCRIPTION
Adds a controlled 13-topic vocabulary (_data/topics.yml, reused from and extending the Research Areas checkboxes already used in collaboration-request.yml) and a collapsible "Filter by topic" section on the People page, so visitors can filter researchers by subfield (MPC, ZKP, FHE, ...) instead of only by sector/location.

The existing free-text `research` field stays as-is for display — it's more descriptive for humans reading the modal than a fixed vocabulary would be. The new `topics` field (array of codes) is purely the machine-matchable backing data for the filter, merged into the same data-tags attribute person-card.html already carries, so it plugs into main.js's existing FILTER_GROUPS logic (OR within a group, AND across groups) with no new filtering machinery — the topic group is read directly off whatever buttons are on the page rather than duplicating the code list in JS.

Migrated all 25 existing researchers' `research` text to topics by hand and had the mappings reviewed before committing, since auto- tagging someone's research area wrong is a real (if small) accuracy risk and four of the entries only had vague signal to go on.

Submission pipeline: add-researcher.yml and edit-researcher.yml gain a Topics checkboxes section (matching the pattern already used for Research Areas in collaboration-request.yml), process-submissions.yml parses checked boxes into codes, and validate_submissions.rb loads _data/topics.yml directly to reject any unknown code.