### PR TITLE
Add photo add/remove to Edit My Profile

### DIFF
--- a/.github/ISSUE_TEMPLATE/edit-researcher.yml
+++ b/.github/ISSUE_TEMPLATE/edit-researcher.yml
@@ -15,6 +15,21 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: photo
+    attributes:
+      label: Photo URL (optional)
+      description: A direct link to an image (jpg/png/webp). Leave blank to leave your current photo unchanged. If filled in, this replaces any existing photo.
+      placeholder: https://example.com/your-photo.jpg
+
+  - type: checkboxes
+    id: remove_photo
+    attributes:
+      label: Remove photo
+      description: Only takes effect if the Photo URL field above is left blank.
+      options:
+        - label: Remove my current photo (falls back to initials)
+
   - type: checkboxes
     id: topics
     attributes:

--- a/.github/scripts/validate_submissions.rb
+++ b/.github/scripts/validate_submissions.rb
@@ -73,6 +73,14 @@ if File.exist?(people_path)
       end
     end
 
+    # `photo` is either a full http(s) URL (submitted via Edit My Profile) or
+    # a site-relative path like /assets/images/people/x.jpg (written by the
+    # fetch-researcher-photos.yml bot) — accept either shape.
+    photo = person["photo"]
+    if photo && !photo.to_s.strip.empty? && photo.to_s.strip !~ URL_RE && !photo.to_s.strip.start_with?("/")
+      error(errors, src, "`photo` must be an http(s) URL or a site-relative path starting with /: #{photo}")
+    end
+
     email = person["email"]
     if email && !email.to_s.strip.empty? && email.to_s.strip !~ EMAIL_RE
       error(errors, src, "`email` is not a valid email address: #{email}")

--- a/.github/workflows/process-submissions.yml
+++ b/.github/workflows/process-submissions.yml
@@ -220,6 +220,8 @@ jobs:
             }
 
             const topicCodes = checkedOptions('Topics \\(optional\\)').map(label => TOPIC_CODE_BY_LABEL[label]).filter(Boolean);
+            const photoUrl = field('Photo URL \\(optional\\)');
+            const removePhotoChecked = checkedOptions('Remove photo').length > 0;
 
             const updates = {
               email:    field('Email ID \\(optional\\)'),
@@ -238,12 +240,19 @@ jobs:
             if (topicCodes.length) {
               updates.topics = `[${topicCodes.join(', ')}]`;
             }
+            if (photoUrl && photoUrl !== '_No response_') {
+              updates.photo = photoUrl;
+            }
 
-            if (Object.keys(updates).length === 0) {
+            // "Remove photo" only takes effect if no new photo URL was given
+            // (a URL always wins — it's the more explicit signal).
+            const removePhoto = removePhotoChecked && !updates.photo;
+
+            if (Object.keys(updates).length === 0 && !removePhoto) {
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: issue.number,
-                body: '❌ No fields to update — please fill in at least one of Email, ORCID, Google Scholar, DBLP, or LinkedIn.',
+                body: '❌ No fields to update — please fill in at least one of Photo, Topics, Email, ORCID, Google Scholar, DBLP, or LinkedIn, or check "Remove my current photo".',
               });
               return;
             }
@@ -292,6 +301,14 @@ jobs:
                 }
               }
               changed.push(key);
+            }
+
+            if (removePhoto) {
+              const photoIdx = lines.findIndex(l => l.trim().startsWith('photo:'));
+              if (photoIdx !== -1) {
+                lines.splice(photoIdx, 1);
+                changed.push('photo (removed)');
+              }
             }
 
             const updatedBody = lines.join('\n');


### PR DESCRIPTION
edit-researcher.yml gains a Photo URL field and a "Remove my current photo" checkbox. A submitted URL always wins over the remove checkbox if both are somehow filled in. Removal actually deletes the `photo:` line from the entry rather than blanking its value, since an empty string is still truthy in Liquid and would render a broken <img src=""> otherwise.

validate_submissions.rb now checks `photo` shape too, but as either an http(s) URL (this new field) or a site-relative path like /assets/images/people/x.jpg — the existing fetch-researcher-photos.yml bot writes the latter, so photo needed its own check rather than reuse of the plain URL-only validation the other link fields share.

Verified the parsing/merge/removal logic against 6 cases (add, replace, remove, URL-wins-over-remove, remove-when-nothing-exists, nothing-filled) via a standalone reproduction of the workflow's JS before touching the real GitHub Actions script.