### PR TITLE
Localize and resize photos submitted via Edit My Profile

### DIFF
--- a/.github/scripts/resize_photo.py
+++ b/.github/scripts/resize_photo.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Downloads a single, directly-linked image and resizes it to the site's
+photo convention, for the Edit My Profile automation's Photo URL field.
+
+Unlike fetch_photos.py — which scrapes a person's *webpage* and scores
+several candidate images to pick the most likely headshot — this script
+takes a URL the researcher already pointed at directly, so there's no
+candidate scoring to do. It exists so a submitted photo lands in the repo
+as a local, optimized file (matching every other photo on the site)
+instead of a live hotlink to whatever server happens to host it, which
+can go away, get hotlink-protected, or be arbitrarily large/unoptimized.
+
+MAX_PX / JPEG_Q intentionally match fetch_photos.py — keep them in sync.
+
+Usage: resize_photo.py <url> <dest_path>
+Exits non-zero with a message on stderr if the URL can't be fetched or
+doesn't decode as an image.
+"""
+
+import io
+import sys
+import urllib.request
+from pathlib import Path
+
+from PIL import Image
+
+MAX_PX = 300
+JPEG_Q = 85
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/125.0.0.0 Safari/537.36"
+    ),
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: resize_photo.py <url> <dest_path>", file=sys.stderr)
+        return 1
+
+    url, dest = sys.argv[1], sys.argv[2]
+
+    try:
+        req = urllib.request.Request(url, headers=HEADERS)
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            raw = resp.read()
+    except Exception as e:
+        print(f"could not fetch URL: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        img = Image.open(io.BytesIO(raw)).convert("RGB")
+    except Exception as e:
+        print(f"not a valid image: {e}", file=sys.stderr)
+        return 1
+
+    img.thumbnail((MAX_PX, MAX_PX), Image.LANCZOS)
+
+    dest_path = Path(dest)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(dest_path, "JPEG", quality=JPEG_Q, optimize=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/process-submissions.yml
+++ b/.github/workflows/process-submissions.yml
@@ -164,6 +164,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Pillow
+        run: pip install --quiet Pillow
+
       - name: Parse issue and update researcher entry
         uses: actions/github-script@v7
         with:
@@ -223,6 +230,11 @@ jobs:
             const photoUrl = field('Photo URL \\(optional\\)');
             const removePhotoChecked = checkedOptions('Remove photo').length > 0;
 
+            function slugify(str) {
+              return str.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+            }
+            const photoRepoPath = `assets/images/people/${slugify(name)}.jpg`;
+
             const updates = {
               email:    field('Email ID \\(optional\\)'),
               orcid:    field('ORCID iD \\(optional\\)'),
@@ -240,21 +252,43 @@ jobs:
             if (topicCodes.length) {
               updates.topics = `[${topicCodes.join(', ')}]`;
             }
-            if (photoUrl && photoUrl !== '_No response_') {
-              updates.photo = photoUrl;
-            }
 
+            const hasPhotoUrl = !!(photoUrl && photoUrl !== '_No response_');
             // "Remove photo" only takes effect if no new photo URL was given
             // (a URL always wins — it's the more explicit signal).
-            const removePhoto = removePhotoChecked && !updates.photo;
+            const removePhoto = removePhotoChecked && !hasPhotoUrl;
 
-            if (Object.keys(updates).length === 0 && !removePhoto) {
+            if (Object.keys(updates).length === 0 && !hasPhotoUrl && !removePhoto) {
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: issue.number,
                 body: '❌ No fields to update — please fill in at least one of Photo, Topics, Email, ORCID, Google Scholar, DBLP, or LinkedIn, or check "Remove my current photo".',
               });
               return;
+            }
+
+            // Download + resize the submitted photo now, before touching git,
+            // so a bad or unfetchable URL fails fast with a clear message
+            // instead of producing a PR with a broken image. This mirrors
+            // fetch-researcher-photos.yml's own resize convention (300px max,
+            // JPEG q85) so a submitted photo becomes a local, optimized file
+            // like every other photo on the site — never a live hotlink.
+            let resizedPhotoBuffer = null;
+            if (hasPhotoUrl) {
+              const { execFileSync } = require('child_process');
+              const fs = require('fs');
+              try {
+                execFileSync('python3', ['.github/scripts/resize_photo.py', photoUrl, photoRepoPath], { stdio: 'inherit' });
+                resizedPhotoBuffer = fs.readFileSync(photoRepoPath);
+              } catch (e) {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: issue.number,
+                  body: '❌ Could not fetch or process that Photo URL. Please make sure it\'s a direct link to an image (jpg/png/webp) that\'s publicly accessible, then try again.',
+                });
+                return;
+              }
+              updates.photo = `/${photoRepoPath}`;
             }
 
             const { data: fileData } = await github.rest.repos.getContent({
@@ -326,6 +360,43 @@ jobs:
               sha: fileData.sha,
               branch,
             });
+
+            if (resizedPhotoBuffer) {
+              let existingPhotoSha;
+              try {
+                const { data: existingPhotoFile } = await github.rest.repos.getContent({
+                  ...context.repo, path: photoRepoPath, ref: 'master',
+                });
+                existingPhotoSha = existingPhotoFile.sha;
+              } catch (e) {
+                existingPhotoSha = undefined; // no existing photo at this path — new file
+              }
+              await github.rest.repos.createOrUpdateFileContents({
+                ...context.repo,
+                path: photoRepoPath,
+                message: `Add/update photo: ${name}`,
+                content: resizedPhotoBuffer.toString('base64'),
+                branch,
+                ...(existingPhotoSha ? { sha: existingPhotoSha } : {}),
+              });
+            }
+
+            if (removePhoto) {
+              try {
+                const { data: existingPhotoFile } = await github.rest.repos.getContent({
+                  ...context.repo, path: photoRepoPath, ref: 'master',
+                });
+                await github.rest.repos.deleteFile({
+                  ...context.repo,
+                  path: photoRepoPath,
+                  message: `Remove photo: ${name}`,
+                  sha: existingPhotoFile.sha,
+                  branch,
+                });
+              } catch (e) {
+                // no local photo file existed at this path — nothing to delete
+              }
+            }
 
             const pr = await github.rest.pulls.create({
               ...context.repo,


### PR DESCRIPTION
Previously, submitting a Photo URL just wrote that raw URL straight into photo: — the one path on the site that would produce a live hotlink instead of a local file, unlike every other photo (the fetch-researcher-photos.yml bot, and the batch of 25 added earlier this session, all resize and store locally).

Adds .github/scripts/resize_photo.py — a minimal counterpart to fetch_photos.py for this exact case: given a URL the researcher already pointed at directly, there's no candidate-scoring to do, just download, resize to the same 300px/JPEG-q85 convention, and save. The edit-researcher job now shells out to it before touching git, so a bad or unfetchable URL fails with a clear comment instead of producing a PR with a broken image or a live external link.

The PR this opens now commits the resized image file itself alongside the updated names-people.yml entry (photo: set to the local /assets/images/people/{slug}.jpg path, not the submitted URL). "Remove my current photo" now also deletes that local file, not just the YAML line, so removed photos don't linger as orphaned files.

Verified end-to-end (not mocked) against the real script: a valid URL resizes and saves correctly, an unfetchable URL fails cleanly before any git operation runs, and no-photo-submitted correctly skips processing entirely.