### PR TITLE
Add social sharing: Star on GitHub, OG/Twitter tags, share buttons

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,11 +8,22 @@
 <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
 <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-<meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
-<meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-<meta property="og:type" content="website">
+{% assign share_title = page.title | default: site.title %}
+{% assign share_description = page.excerpt | strip_html | strip_newlines | truncate: 160 %}
+{% unless share_description %}{% assign share_description = site.description %}{% endunless %}
+{% assign share_image = page.image | default: '/assets/images/bio-photo-new.png' | absolute_url %}
+
+<meta property="og:title" content="{{ share_title }}">
+<meta property="og:description" content="{{ share_description }}">
+<meta property="og:type" content="{% if page.layout == 'post' %}article{% else %}website{% endif %}">
 <meta property="og:url" content="{{ page.url | absolute_url }}">
-<meta property="og:image" content="{{ '/assets/images/bio-photo-new.png' | absolute_url }}">
+<meta property="og:image" content="{{ share_image }}">
+<meta property="og:site_name" content="{{ site.title }}">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ share_title }}">
+<meta name="twitter:description" content="{{ share_description }}">
+<meta name="twitter:image" content="{{ share_image }}">
 
 <link rel="canonical" href="{{ page.url | absolute_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,11 +40,19 @@
         </li>
       </ul>
 
-      <!-- Theme toggle -->
-      <div class="theme-toggle" id="theme-toggle" aria-label="Switch theme">
-        <button class="theme-btn" data-theme-btn="dark"  title="Dark">🌙</button>
-        <button class="theme-btn" data-theme-btn="light" title="Light">☀️</button>
-        <button class="theme-btn" data-theme-btn="auto"  title="Auto (system)">💻</button>
+      <div class="nav-actions">
+        <a href="https://github.com/{{ site.github_username | default: 'cryptography-research-india' }}/cryptography-research-india.github.io"
+           class="github-star-btn" target="_blank" rel="noopener" aria-label="Star this project on GitHub">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+          <span class="star-btn-label">Star on GitHub</span>
+        </a>
+
+        <!-- Theme toggle -->
+        <div class="theme-toggle" id="theme-toggle" aria-label="Switch theme">
+          <button class="theme-btn" data-theme-btn="dark"  title="Dark">🌙</button>
+          <button class="theme-btn" data-theme-btn="light" title="Light">☀️</button>
+          <button class="theme-btn" data-theme-btn="auto"  title="Auto (system)">💻</button>
+        </div>
       </div>
     </div>
   </nav>

--- a/_includes/position-card.html
+++ b/_includes/position-card.html
@@ -1,6 +1,8 @@
 {% assign pos = include.position %}
 {% assign closed = include.closed %}
-<article class="position-card glass{% if closed %} position-card-closed{% endif %}">
+{% assign pos_anchor = "position-" | append: pos.slug %}
+{% assign pos_share_url = "/positions/#" | append: pos_anchor %}
+<article class="position-card glass{% if closed %} position-card-closed{% endif %}" id="{{ pos_anchor }}">
   <div class="position-card-header">
     <div class="position-card-heading">
       <h3 class="position-card-title">{{ pos.title }}</h3>
@@ -36,5 +38,9 @@
     {% if pos.contact %}
     <a href="mailto:{{ pos.contact }}" class="btn btn-ghost btn-sm">Contact</a>
     {% endif %}
+  </div>
+
+  <div class="share-row">
+    {% include share-buttons.html url=pos_share_url title=pos.title %}
   </div>
 </article>

--- a/_includes/share-buttons.html
+++ b/_includes/share-buttons.html
@@ -1,0 +1,24 @@
+{% assign share_url = include.url | absolute_url %}
+{% assign share_title = include.title | default: site.title %}
+<div class="share-buttons">
+  <span class="share-label">Share:</span>
+  <a class="share-btn share-btn-x"
+     href="https://twitter.com/intent/tweet?text={{ share_title | url_encode }}&url={{ share_url | url_encode }}"
+     target="_blank" rel="noopener" aria-label="Share on X">
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.26 10.99h-6.53l-5.12-6.7-5.86 6.7H1.76l7.73-8.83L1.55 2.25h6.55l4.63 6.42 5.51-6.42Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"/></svg>
+  </a>
+  <a class="share-btn share-btn-linkedin"
+     href="https://www.linkedin.com/sharing/share-offsite/?url={{ share_url | url_encode }}"
+     target="_blank" rel="noopener" aria-label="Share on LinkedIn">
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+  </a>
+  <a class="share-btn share-btn-whatsapp"
+     href="https://wa.me/?text={{ share_title | url_encode }}%20{{ share_url | url_encode }}"
+     target="_blank" rel="noopener" aria-label="Share on WhatsApp">
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-1.746-.872-2.892-1.552-4.036-3.518-.305-.526.305-.489.874-1.63.098-.199.05-.372-.05-.521-.098-.15-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.05 3.132 4.982 4.264 2.933 1.132 2.933.754 3.999.629 1.065-.125 1.756-.874 2.028-1.462.272-.588.272-1.086.198-1.163-.074-.078-.198-.148-.371-.198zM12.05 21.785h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884zm8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg>
+  </a>
+  <button type="button" class="share-btn share-btn-copy" data-share-url="{{ share_url }}" aria-label="Copy link">
+    <svg class="icon-default" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+    <svg class="icon-copied" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>
+  </button>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -63,6 +63,10 @@ layout: default
           </a>
           {% endif %}
         </div>
+
+        <div class="share-row">
+          {% include share-buttons.html url=page.url title=page.title %}
+        </div>
       </div>
     </div>
   </div>

--- a/_pages/collaborations.md
+++ b/_pages/collaborations.md
@@ -68,7 +68,10 @@ permalink: /collaborations/
     {% if site.data.collaborations.size > 0 %}
     <div class="collab-grid" id="collab-grid">
       {% for collab in site.data.collaborations %}
-      <div class="collab-card glass">
+      {% assign collab_anchor = collab.name | append: "-" | append: collab.topic | slugify %}
+      {% assign collab_anchor = "collab-" | append: collab_anchor %}
+      {% assign collab_share_url = "/collaborations/#" | append: collab_anchor %}
+      <div class="collab-card glass" id="{{ collab_anchor }}">
         <div class="collab-card-header">
           <div class="collab-card-meta">
             <span class="collab-card-name">{{ collab.name }}</span>
@@ -99,6 +102,10 @@ permalink: /collaborations/
             {% endif %}
             <a href="mailto:{{ collab.contact }}" class="btn btn-sm btn-primary">Get in touch</a>
           </div>
+        </div>
+
+        <div class="share-row">
+          {% include share-buttons.html url=collab_share_url title=collab.topic %}
         </div>
       </div>
       {% endfor %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1733,6 +1733,7 @@ body.modal-open {
   border-radius: var(--radius-lg);
   padding: 1.5rem;
   transition: all var(--transition-slow);
+  scroll-margin-top: 90px;
 }
 
 .position-card:hover {
@@ -2040,6 +2041,14 @@ body.modal-open {
     display: flex;
   }
 
+  .star-btn-label {
+    display: none;
+  }
+
+  .github-star-btn {
+    padding: 0.5rem;
+  }
+
   .nav-links {
     position: fixed;
     top: 64px;
@@ -2222,6 +2231,98 @@ body.modal-open {
 .comments-setup-notice a { color: var(--green); }
 
 /* ── Theme Toggle Button ─────────────────────────────────── */
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-shrink: 0;
+}
+
+.github-star-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.8rem;
+  font-family: var(--font-heading);
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--glass);
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.github-star-btn:hover {
+  color: var(--green);
+  border-color: rgba(0,255,136,0.4);
+  background: var(--green-dim);
+}
+
+.github-star-btn svg {
+  flex-shrink: 0;
+}
+
+/* ── Share Buttons ────────────────────────────────────────── */
+.share-buttons {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.share-label {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  margin-right: 0.15rem;
+}
+
+.share-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--glass);
+  color: var(--text-muted);
+  transition: all var(--transition);
+  cursor: pointer;
+}
+
+.share-btn:hover {
+  color: var(--text);
+  border-color: var(--border-hover);
+  background: var(--glass-strong);
+}
+
+.share-btn-copy .icon-copied {
+  display: none;
+}
+
+.share-btn-copy.copied .icon-default {
+  display: none;
+}
+
+.share-btn-copy.copied .icon-copied {
+  display: flex;
+}
+
+.share-btn-copy.copied {
+  color: var(--green);
+  border-color: rgba(0,255,136,0.4);
+  background: var(--green-dim);
+}
+
+.share-row {
+  margin-top: 0.9rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--border);
+}
+
 .theme-toggle {
   display: flex;
   align-items: center;
@@ -2385,6 +2486,7 @@ body.modal-open {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  scroll-margin-top: 90px;
   transition: border-color var(--transition), transform var(--transition);
 
   &:hover {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -72,6 +72,40 @@
   });
 
   /* ============================================================
+     CLIPBOARD COPY (shared helper — used by the researcher modal's
+     Copy Email button and the share buttons' Copy Link button)
+     ============================================================ */
+  function copyTextToClipboard(text, onSuccess, onFail) {
+    // Fallback for browsers/contexts that reject the async Clipboard API
+    // (no permission granted, insecure context, older browser). execCommand
+    // is deprecated but still works synchronously inside a real user
+    // gesture, which every caller of this function is.
+    function fallbackCopy() {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      var ok = false;
+      try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+      document.body.removeChild(ta);
+      return ok;
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(onSuccess, function () {
+        if (fallbackCopy()) onSuccess(); else onFail();
+      });
+    } else if (fallbackCopy()) {
+      onSuccess();
+    } else {
+      onFail();
+    }
+  }
+
+  /* ============================================================
      PEOPLE FILTERING
      ============================================================ */
   var filterBtns = document.querySelectorAll('.filter-btn');
@@ -318,45 +352,15 @@
           copyBtn.className = 'btn btn-ghost btn-sm';
           copyBtn.innerHTML = copyIcon() + ' Copy Email';
 
-          function showCopied() {
-            copyBtn.innerHTML = checkIcon() + ' Copied!';
-            setTimeout(function () {
-              copyBtn.innerHTML = copyIcon() + ' Copy Email';
-            }, 1800);
-          }
-
-          // Fallback for browsers/contexts that reject the async Clipboard
-          // API (no permission granted, insecure context, older browser).
-          // execCommand is deprecated but still works synchronously inside a
-          // real user gesture, which this click handler always is.
-          function fallbackCopy() {
-            var ta = document.createElement('textarea');
-            ta.value = email;
-            ta.style.position = 'fixed';
-            ta.style.opacity = '0';
-            document.body.appendChild(ta);
-            ta.focus();
-            ta.select();
-            var ok = false;
-            try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
-            document.body.removeChild(ta);
-            return ok;
-          }
-
           copyBtn.addEventListener('click', function () {
-            if (navigator.clipboard && navigator.clipboard.writeText) {
-              navigator.clipboard.writeText(email).then(showCopied, function () {
-                if (fallbackCopy()) {
-                  showCopied();
-                } else {
-                  copyBtn.innerHTML = 'Copy failed — ' + email;
-                }
-              });
-            } else if (fallbackCopy()) {
-              showCopied();
-            } else {
+            copyTextToClipboard(email, function () {
+              copyBtn.innerHTML = checkIcon() + ' Copied!';
+              setTimeout(function () {
+                copyBtn.innerHTML = copyIcon() + ' Copy Email';
+              }, 1800);
+            }, function () {
               copyBtn.innerHTML = 'Copy failed — ' + email;
-            }
+            });
           });
           modalFooter.appendChild(copyBtn);
         }
@@ -546,5 +550,28 @@
       }
     }, { passive: true });
   }
+
+  /* ============================================================
+     SHARE BUTTONS — Copy Link
+     (the X/LinkedIn/WhatsApp buttons are plain share-intent links
+     and need no JS; only Copy Link needs one)
+     ============================================================ */
+  document.querySelectorAll('.share-btn-copy').forEach(function (btn) {
+    var url = btn.getAttribute('data-share-url');
+    if (!url) return;
+
+    btn.addEventListener('click', function () {
+      copyTextToClipboard(url, function () {
+        btn.classList.add('copied');
+        btn.setAttribute('aria-label', 'Link copied');
+        setTimeout(function () {
+          btn.classList.remove('copied');
+          btn.setAttribute('aria-label', 'Copy link');
+        }, 1800);
+      }, function () {
+        btn.setAttribute('aria-label', 'Copy failed — select and copy the URL manually');
+      });
+    });
+  });
 
 })();


### PR DESCRIPTION
Adds Twitter Card tags and a page-aware Open Graph image to head.html, a Star on GitHub button in the header, and a reusable share-buttons include (X/LinkedIn/WhatsApp intents + Copy Link) wired into blog posts, positions, and collaboration listings with deep-linkable anchors.