### PR TITLE
Fix mobile nav ordering, refresh blog copy, add homepage share CTA

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -144,3 +144,18 @@ layout: default
     </div>
   </div>
 </section>
+
+<!-- Spread the Word -->
+<section class="section section-share-cta">
+  <div class="container">
+    <div class="share-cta glass">
+      <div class="share-cta-content">
+        <h2>Know a cryptographer in India?</h2>
+        <p>Help grow the community — share CRIYPT with researchers, students, and colleagues who should be part of it.</p>
+      </div>
+      <div class="share-cta-buttons">
+        {% include share-buttons.html url="/" title="Cryptography Researchers of India — connecting cryptography researchers across India" %}
+      </div>
+    </div>
+  </div>
+</section>

--- a/_posts/2025-01-02-meet-the-cryptographers-of-india.md
+++ b/_posts/2025-01-02-meet-the-cryptographers-of-india.md
@@ -12,8 +12,8 @@ Having a curated list of cryptographers in India is essential for several reason
 
 Firstly, India is a vast country with a diverse and thriving research community. However, the lack of a comprehensive list can often be a bottleneck for collaboration and interdisciplinary research. By creating a centralized platform that brings together researchers from various corners of the country, we aim to facilitate communication and collaboration within the community.
 
-This is particularly important for early stage researchers or graduate students, who may not be aware of the full extent of possibilities within the field of cryptography in India. A list such as this can help them connect with others working on similar topics, and expand their knowledge and understanding of the field.
+This is particularly important for early stage researchers or graduate students, who may not be aware of the full extent of possibilities within the field of cryptography in India. A directory such as this can help them connect with others working on similar topics, and expand their knowledge and understanding of the field.
 
-Overall, the goal of this list is to contribute to the advancement of cryptography research in India, and ultimately to the benefit of society as a whole. We hope that this platform will serve as a valuable resource for researchers in the field, and encourage collaboration and innovation within the community.
+Overall, the goal of this directory is to contribute to the advancement of cryptography research in India, and ultimately to the benefit of society as a whole. We hope that this platform will serve as a valuable resource for researchers in the field, and encourage collaboration and innovation within the community.
 
-You can find the list [here]({{ site.baseurl }}{% link _pages/people.md %}).
+You can browse the directory [here]({{ site.baseurl }}{% link _pages/people.md %}) — search or filter by topic, and click on a researcher's card to see their full profile, including links to their publications and academic pages. Know someone who should be listed, or want to add or update your own profile? You can do that directly from the People page too.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1544,6 +1544,31 @@ body.modal-open {
   flex-wrap: wrap;
 }
 
+.share-cta {
+  border-radius: var(--radius-xl);
+  padding: 2.5rem 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.share-cta-content h2 {
+  font-size: 1.4rem;
+  margin-bottom: 0.4rem;
+}
+
+.share-cta-content p {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  margin-bottom: 0;
+}
+
+.share-cta-buttons .share-label {
+  display: none;
+}
+
 /* ============================================================
    RESOURCES PAGE
    ============================================================ */
@@ -2037,8 +2062,17 @@ body.modal-open {
    ============================================================ */
 @media (max-width: 768px) {
   /* Nav */
+  .navbar-brand {
+    order: 1;
+  }
+
+  .nav-actions {
+    order: 2;
+  }
+
   .nav-toggle {
     display: flex;
+    order: 3;
   }
 
   .star-btn-label {


### PR DESCRIPTION
The hamburger button was landing in the middle of the mobile navbar because the nav-links dropdown drops out of flex flow at that breakpoint, leaving it sandwiched between the brand and nav actions. Also updates the "Meet the Cryptographers" post to describe the current searchable/filterable People page instead of the old flat list, and adds a "spread the word" share section to the homepage.