### PR TITLE
Guard against SSRF in the photo-fetching scripts

### DIFF
--- a/.github/scripts/fetch_photos.py
+++ b/.github/scripts/fetch_photos.py
@@ -20,7 +20,9 @@ Updates:   _data/names-people.yml  (adds 'photo' field, preserves formatting)
 """
 
 import io
+import ipaddress
 import re
+import socket
 import sys
 import httpx
 from dataclasses import dataclass, field
@@ -56,6 +58,7 @@ MAX_PX     = 300
 JPEG_Q     = 85
 MIN_SCORE  = 0          # minimum score to accept an image
 MAX_CANDIDATES = 12     # max images to evaluate per person
+MAX_REDIRECTS = 5
 
 HEADERS = {
     "User-Agent": (
@@ -122,6 +125,58 @@ def slugify(name: str) -> str:
 
 def _keywords(text: str) -> set[str]:
     return {w.lower() for w in re.split(r"[/_\-. ]", text) if w}
+
+
+# ── SSRF guard ────────────────────────────────────────────────────────────────
+# `webpage` (and every image URL scraped off of it) ultimately comes from a
+# submitted researcher profile — nothing stops it from pointing at internal
+# infrastructure (the cloud metadata endpoint, localhost, a private-network
+# service) instead of a real public page/image. Reject anything whose scheme
+# isn't http(s) or whose hostname resolves to a private/loopback/link-local/
+# reserved address, and re-check on every redirect hop too (a same-origin-
+# looking URL can still 302 to an internal address once fetched).
+
+def _is_public_ip(ip_str: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    # Treat an IPv4-mapped IPv6 address (::ffff:127.0.0.1) as its mapped
+    # IPv4 form — `is_loopback`/`is_private` on the IPv6 wrapper itself
+    # wouldn't otherwise catch it.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return not (
+        ip.is_private or ip.is_loopback or ip.is_link_local
+        or ip.is_multicast or ip.is_reserved or ip.is_unspecified
+    )
+
+
+def is_safe_url(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return False
+    try:
+        infos = socket.getaddrinfo(parsed.hostname, None)
+    except socket.gaierror:
+        return False
+    resolved = {info[4][0] for info in infos}
+    return bool(resolved) and all(_is_public_ip(ip) for ip in resolved)
+
+
+def safe_get(client: httpx.Client, url: str, **kwargs) -> httpx.Response:
+    """`client.get(url, follow_redirects=True)`, but re-validates `is_safe_url`
+    on the original URL and on every redirect hop, instead of trusting
+    httpx's own redirect-following not to land on an internal address."""
+    for _ in range(MAX_REDIRECTS + 1):
+        if not is_safe_url(url):
+            raise httpx.RequestError(f"refusing to fetch unsafe URL: {url}")
+        r = client.get(url, follow_redirects=False, **kwargs)
+        if r.is_redirect:
+            url = urljoin(str(r.url), r.headers.get("location", ""))
+            continue
+        return r
+    raise httpx.RequestError(f"too many redirects: {url}")
 
 
 # ── Candidate collection ──────────────────────────────────────────────────────
@@ -221,7 +276,7 @@ def _score(c: Candidate) -> int:
 
 def _download(url: str, client: httpx.Client) -> bytes | None:
     try:
-        r = client.get(url, timeout=20, follow_redirects=True)
+        r = safe_get(client, url, timeout=20)
         r.raise_for_status()
         ct = r.headers.get("content-type", "")
         if not ct.startswith("image/"):
@@ -262,7 +317,7 @@ def _save(raw: bytes, dest: Path) -> bool:
 def best_photo(page_url: str, client: httpx.Client) -> bytes | None:
     """Return raw bytes of the best profile photo found on *page_url*, or None."""
     try:
-        r = client.get(page_url, timeout=20, follow_redirects=True)
+        r = safe_get(client, page_url, timeout=20)
         r.raise_for_status()
     except Exception as e:
         print(f"    page fetch failed: {e}")

--- a/.github/scripts/resize_photo.py
+++ b/.github/scripts/resize_photo.py
@@ -19,14 +19,19 @@ doesn't decode as an image.
 """
 
 import io
+import ipaddress
+import socket
 import sys
+import urllib.error
 import urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
 
 from PIL import Image
 
 MAX_PX = 300
 JPEG_Q = 85
+MAX_REDIRECTS = 5
 
 HEADERS = {
     "User-Agent": (
@@ -37,6 +42,52 @@ HEADERS = {
 }
 
 
+# ── SSRF guard ────────────────────────────────────────────────────────────────
+# `url` is a submitted Photo URL field — nothing stops a submitter from
+# pointing it at internal infrastructure (the cloud metadata endpoint,
+# localhost, a private-network service) instead of a real public image.
+# Reject anything whose scheme isn't http(s) or whose hostname resolves to
+# a private/loopback/link-local/reserved address, and re-check on every
+# redirect hop too (a same-origin-looking URL can still 302 to an internal
+# address once fetched).
+
+def _is_public_ip(ip_str: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    # Treat an IPv4-mapped IPv6 address (::ffff:127.0.0.1) as its mapped
+    # IPv4 form — `is_loopback`/`is_private` on the IPv6 wrapper itself
+    # wouldn't otherwise catch it.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return not (
+        ip.is_private or ip.is_loopback or ip.is_link_local
+        or ip.is_multicast or ip.is_reserved or ip.is_unspecified
+    )
+
+
+def is_safe_url(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return False
+    try:
+        infos = socket.getaddrinfo(parsed.hostname, None)
+    except socket.gaierror:
+        return False
+    resolved = {info[4][0] for info in infos}
+    return bool(resolved) and all(_is_public_ip(ip) for ip in resolved)
+
+
+class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    max_redirections = MAX_REDIRECTS
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        if not is_safe_url(newurl):
+            raise urllib.error.URLError(f"refusing to follow redirect to unsafe URL: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
 def main() -> int:
     if len(sys.argv) != 3:
         print("usage: resize_photo.py <url> <dest_path>", file=sys.stderr)
@@ -44,9 +95,14 @@ def main() -> int:
 
     url, dest = sys.argv[1], sys.argv[2]
 
+    if not is_safe_url(url):
+        print("URL must be http(s) and resolve to a public address", file=sys.stderr)
+        return 1
+
     try:
+        opener = urllib.request.build_opener(SafeRedirectHandler)
         req = urllib.request.Request(url, headers=HEADERS)
-        with urllib.request.urlopen(req, timeout=20) as resp:
+        with opener.open(req, timeout=20) as resp:
             raw = resp.read()
     except Exception as e:
         print(f"could not fetch URL: {e}", file=sys.stderr)


### PR DESCRIPTION
Both resize_photo.py (invoked automatically on every Add Researcher / Edit My Profile submission's Photo URL) and fetch_photos.py (the workflow_dispatch bulk photo fetcher) take a URL that ultimately comes from a submitted researcher profile — nothing previously stopped it from pointing at internal infrastructure (cloud metadata endpoint, localhost, a private-network service) instead of a real public image/page.

Add an is_safe_url() check that rejects non-http(s) schemes and any hostname resolving to a private/loopback/link-local/reserved address, and re-check on every redirect hop too, since a same-origin-looking URL can still 302 to an internal address once fetched (a custom HTTPRedirectHandler for resize_photo.py's urllib usage, a safe_get() wrapper around manual redirect-following for fetch_photos.py's httpx usage).