### PR TITLE
Escape Recent Papers homepage section, validate posts and papers feed

### DIFF
--- a/.github/scripts/fetch_recent_papers.py
+++ b/.github/scripts/fetch_recent_papers.py
@@ -81,7 +81,10 @@ def parse_items(xml_bytes):
         title = (item.findtext("title") or "").strip()
         link = (item.findtext("link") or "").strip()
         pub_raw = (item.findtext("pubDate") or "").strip()
-        if not title or not link:
+        # The feed's <link> ends up as a bare href on the homepage — reject
+        # anything that isn't a plain http(s) URL (e.g. a javascript: URI)
+        # rather than trusting IACR's feed content unconditionally.
+        if not title or not link or not re.match(r"^https?://", link, re.IGNORECASE):
             continue
         creators = []
         for child in item:

--- a/.github/scripts/validate_submissions.rb
+++ b/.github/scripts/validate_submissions.rb
@@ -9,7 +9,11 @@
 # Checks, per source:
 #   _data/names-people.yml   - required keys, tag/topic vocabulary, URL shape, dup names
 #   _data/collaborations.yml - required keys, email shape, URL shape, dup (name+topic)
+#   _data/grad-postdocs.yml  - required keys, position vocabulary, URL shape, dup names
 #   _positions/*.md          - required front matter keys, URL shape, dup (title+org)
+#   _posts/*.md               - required front matter keys, dup (title+date), suspicious content
+#   _data/recent_papers.yml  - required keys, URL shape, suspicious content (third-party feed content)
+#   resource lists            - URL shape, unescaped angle brackets, suspicious content
 #
 # Exits non-zero (and prints "::error::" annotations) if any check fails.
 
@@ -24,6 +28,11 @@ EMAIL_RE = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
 ORCID_RE = /\A\d{4}-\d{4}-\d{4}-\d{3}[\dX]\z/
 VALID_SECTOR_TAGS = %w[ACADEMIA INDUSTRY].freeze
 VALID_LOCATION_TAGS = %w[WORKING_IN_INDIA WORKING_ABROAD].freeze
+# Best-effort regex check (not a full HTML parser) for content that ends up
+# rendered as raw HTML somewhere on the site — catches the common cases
+# (script tag, javascript: URI, inline event handler) rather than
+# guaranteeing every possible injection is caught.
+SUSPICIOUS_RE = /<script|javascript:|data:text\/html|on\w+\s*=/i
 
 topics_path = File.join(ROOT, "_data/topics.yml")
 VALID_TOPIC_CODES = if File.exist?(topics_path)
@@ -238,15 +247,103 @@ else
   puts "SKIP  #{positions_dir}/ not found"
 end
 
+# ── _posts/*.md ─────────────────────────────────────────────────────────────
+posts_dir = File.join(ROOT, "_posts")
+if Dir.exist?(posts_dir)
+  seen_posts = {}
+
+  Dir.glob(File.join(posts_dir, "*.md")).sort.each do |path|
+    rel = path.sub("#{ROOT}/", "")
+    raw = File.read(path)
+
+    unless raw.start_with?("---")
+      error(errors, rel, "missing YAML front matter")
+      next
+    end
+
+    parts = raw.split(/^---\s*$/, 3)
+    if parts.length < 3
+      error(errors, rel, "malformed front matter (no closing `---`)")
+      next
+    end
+
+    # Post `date:` values are typically full timestamps (e.g.
+    # `2025-01-01T00:00:00-04:00`), which YAML parses as `Time`, not
+    # `Date` — unlike every other date field in this file.
+    front = YAML.safe_load(parts[1], permitted_classes: [Date, Time], aliases: true) || {}
+    body = parts[2]
+
+    # `author` is deliberately optional here — post.html only shows a
+    # byline `{% if page.author %}`, and the site's own maintainer-written
+    # posts (predating the Submit Blog Post automation) have none.
+    %w[title date].each do |key|
+      error(errors, rel, "missing required field `#{key}`") if front[key].to_s.strip.empty?
+    end
+
+    if front["title"].to_s =~ SUSPICIOUS_RE || front["author"].to_s =~ SUSPICIOUS_RE
+      error(errors, rel, "front matter contains a suspicious pattern (script tag, javascript: URI, or inline event handler) — review carefully before merging")
+    end
+
+    if body =~ SUSPICIOUS_RE
+      error(errors, rel, "post body contains a suspicious pattern (script tag, javascript: URI, or inline event handler) — review carefully before merging")
+    end
+
+    date = front["date"]
+    next if front["title"].to_s.strip.empty? || date.to_s.strip.empty?
+
+    key = "#{normalize(front['title'])}::#{date}"
+    if seen_posts[key]
+      error(errors, rel, "duplicate post (same title + date as #{seen_posts[key]})")
+    else
+      seen_posts[key] = rel
+    end
+  end
+else
+  puts "SKIP  #{posts_dir}/ not found"
+end
+
+# ── _data/recent_papers.yml ─────────────────────────────────────────────────
+# Written entirely by an unattended weekly fetch from the public IACR
+# ePrint RSS feed (fetch_recent_papers.py) and rendered on the homepage —
+# title/url/author names are third-party content nobody at CRIYPT chose,
+# so this gets the same suspicious-content scan as the resource lists
+# rather than being trusted just because it's machine-generated.
+papers_path = File.join(ROOT, "_data/recent_papers.yml")
+if File.exist?(papers_path)
+  papers = YAML.safe_load_file(papers_path, permitted_classes: [Date], aliases: true) || []
+
+  papers.each_with_index do |paper, i|
+    src = "_data/recent_papers.yml entry ##{i + 1} (#{paper['title'] || 'untitled'})"
+
+    %w[title url].each do |key|
+      error(errors, src, "missing required field `#{key}`") if paper[key].to_s.strip.empty?
+    end
+
+    url = paper["url"]
+    if url && !url.to_s.strip.empty? && url.to_s.strip !~ URL_RE
+      error(errors, src, "`url` is not a valid http(s) URL: #{url}")
+    end
+
+    if paper["title"].to_s =~ SUSPICIOUS_RE
+      error(errors, src, "title contains a suspicious pattern (script tag, javascript: URI, or inline event handler): #{paper['title'].inspect}")
+    end
+
+    (paper["authors"] || []).each do |author|
+      name = author.is_a?(Hash) ? author["name"] : nil
+      if name.to_s =~ SUSPICIOUS_RE
+        error(errors, src, "author name contains a suspicious pattern: #{name.inspect}")
+      end
+    end
+  end
+else
+  puts "SKIP  #{papers_path} not found"
+end
+
 # ── Resource lists (_pages/resources.md, _resources/topics/*.md) ──────────
 # These files are rendered as raw HTML by Jekyll (the Add Resource
 # automation writes plain <li><a href="...">...</a></li> markup directly),
 # so a malformed/malicious entry here is a stored-XSS risk, not just bad
-# data. This is a best-effort regex check, not a full HTML parser — it
-# catches the common cases (bad URL scheme, unescaped angle brackets,
-# obviously suspicious content) rather than guaranteeing every possible
-# injection is caught.
-SUSPICIOUS_RE = /<script|javascript:|data:text\/html|on\w+\s*=/i
+# data.
 resource_files = ([File.join(ROOT, "_pages/resources.md")] + Dir.glob(File.join(ROOT, "_resources/topics/*.md"))).select { |p| File.exist?(p) }
 
 resource_files.each do |path|

--- a/.github/workflows/validate-submissions.yml
+++ b/.github/workflows/validate-submissions.yml
@@ -7,7 +7,9 @@ on:
       - "_data/collaborations.yml"
       - "_data/topics.yml"
       - "_data/grad-postdocs.yml"
+      - "_data/recent_papers.yml"
       - "_positions/**"
+      - "_posts/**"
       - "_pages/resources.md"
       - "_resources/topics/**"
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -141,11 +141,11 @@ layout: default
       {% for paper in site.data.recent_papers limit:6 %}
       <div class="paper-card glass">
         <h3 class="paper-card-title">
-          <a href="{{ paper.url }}" target="_blank" rel="noopener">{{ paper.title }}</a>
+          <a href="{{ paper.url | escape }}" target="_blank" rel="noopener">{{ paper.title | escape }}</a>
         </h3>
         <p class="paper-card-authors">
           {% for author in paper.authors %}
-            {% if author.slug %}<a href="{{ '/people/' | relative_url }}#{{ author.slug }}" class="paper-author-link">{{ author.name }}</a>{% else %}<span>{{ author.name }}</span>{% endif %}{% unless forloop.last %}, {% endunless %}
+            {% if author.slug %}<a href="{{ '/people/' | relative_url }}#{{ author.slug }}" class="paper-author-link">{{ author.name | escape }}</a>{% else %}<span>{{ author.name | escape }}</span>{% endif %}{% unless forloop.last %}, {% endunless %}
           {% endfor %}
         </p>
         {% if paper.date %}


### PR DESCRIPTION
The homepage's Recent Papers section rendered title/url/author name straight from the public IACR ePrint RSS feed with no escaping at all, and paper.url had no scheme check anywhere backing it (unlike every other URL field on the site) — third-party feed content, not something the escaping/validation passes in the last few PRs ever touched.

- home.html: escape paper.title, paper.url (href), and author.name.
- fetch_recent_papers.py: drop any feed item whose <link> isn't a plain http(s) URL before it's ever written to _data/recent_papers.yml.
- validate_submissions.rb: add a recent_papers.yml section (required fields, URL shape, suspicious-pattern scan on title/author names — same treatment as the resource lists, since this is also machine-written third-party content) and a _posts/*.md section (required fields, duplicate check, suspicious-pattern scan on front matter and body) — posts had zero validation coverage even after the escaping fixes landed. Hoisted SUSPICIOUS_RE to the top so both new sections and the existing resource-list check can share it.
- validate-submissions.yml: watch _posts/** and _data/recent_papers.yml.

Verified with negative tests: injected script-tag/quote-breakout payloads into a test post and test recent_papers.yml entries, confirmed validate_submissions.rb catches every one (bad URL, missing field, suspicious title/author/body), then confirmed the home.html escaping independently renders any such payload as safe text rather than live markup. Real data continues to pass validation and build/render unchanged.