### PR TITLE
Add a Read more toggle to collaboration cards

### DIFF
--- a/_pages/collaborations.md
+++ b/_pages/collaborations.md
@@ -84,6 +84,7 @@ permalink: /collaborations/
 
         <h3 class="collab-card-topic">{{ collab.topic | escape }}</h3>
         <p class="collab-card-desc">{{ collab.description | escape }}</p>
+        <button type="button" class="collab-read-more">Read more</button>
 
         <div class="collab-card-areas">
           {% for area in collab.areas %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -2903,6 +2903,33 @@ body.modal-open {
   overflow: hidden;
 }
 
+.collab-card-desc.expanded {
+  -webkit-line-clamp: unset;
+  overflow: visible;
+}
+
+.collab-read-more {
+  display: inline-flex;
+  align-self: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-top: -0.4rem;
+  font-size: 0.82rem;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--cyan);
+  cursor: pointer;
+}
+
+.collab-read-more:hover {
+  text-decoration: underline;
+}
+
+.collab-read-more.hidden {
+  display: none;
+}
+
 .collab-card-areas {
   display: flex;
   flex-wrap: wrap;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -686,4 +686,24 @@
     updateEmergingRows();
   }
 
+  // ── Collaboration card "Read more" ──────────────────────────────────────
+  // The description is CSS-clamped to 4 lines (see .collab-card-desc) so
+  // cards stay a consistent height — only show the toggle on cards where
+  // the clamp is actually cutting text off.
+  document.querySelectorAll('.collab-card').forEach(function (card) {
+    var desc = card.querySelector('.collab-card-desc');
+    var btn = card.querySelector('.collab-read-more');
+    if (!desc || !btn) return;
+
+    if (desc.scrollHeight <= desc.clientHeight + 1) {
+      btn.classList.add('hidden');
+      return;
+    }
+
+    btn.addEventListener('click', function () {
+      var expanded = desc.classList.toggle('expanded');
+      btn.textContent = expanded ? 'Show less' : 'Read more';
+    });
+  });
+
 })();


### PR DESCRIPTION
.collab-card-desc clamps the description to 4 lines with no way to see the rest — any post longer than a couple of sentences was silently cut off with zero affordance to read it. Adds a Read more/Show less toggle that expands the description in place, shown only on cards where the clamp is actually cutting text off.